### PR TITLE
Update maven coordinates for Store 4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,22 +46,22 @@ allprojects {
 
 ext {
     // POM file
-    GROUP = "com.dropbox.android"
+    GROUP = "com.dropbox.mobile.store"
     VERSION_NAME = "4.0.0-SNAPSHOT"
     POM_PACKAGING = "pom"
     POM_DESCRIPTION = "Store4 is built with Kotlin Coroutines"
 
-    POM_URL = "https://github.com/nytimes/Store/"
-    POM_SCM_URL = "https://github.com/nytimes/Store/"
-    POM_SCM_CONNECTION = "scm:git:https://github.com/nytm/Store.git"
-    POM_SCM_DEV_CONNECTION = "scm:git:git@github.com:nytm/Store.git"
+    POM_URL = "https://github.com/dropbox/Store/"
+    POM_SCM_URL = "https://github.com/dropbox/Store/"
+    POM_SCM_CONNECTION = "scm:git:https://github.com/dropbox/Store.git"
+    POM_SCM_DEV_CONNECTION = "scm:git:git@github.com:dropbox/Store.git"
 
     POM_LICENCE_NAME = "Apache License"
-    POM_LICENCE_URL = "http://www.apache.org/licenses/"
+    POM_LICENCE_URL = "http://www.apache.org/licenses/LICENSE-2.0"
     POM_LICENCE_DIST = "repo"
 
-    POM_DEVELOPER_ID = "nytimesandroid"
-    POM_DEVELOPER_NAME = "New York Times"
+    POM_DEVELOPER_ID = "dropbox"
+    POM_DEVELOPER_NAME = "Dropbox"
 }
 
 

--- a/cache/gradle.properties
+++ b/cache/gradle.properties
@@ -1,3 +1,3 @@
-POM_NAME=com.dropbox.android
-POM_ARTIFACT_ID=cache3
+POM_NAME=com.dropbox.mobile.store
+POM_ARTIFACT_ID=cache4
 POM_PACKAGING=aar

--- a/filesystem/gradle.properties
+++ b/filesystem/gradle.properties
@@ -1,3 +1,3 @@
-POM_NAME=com.dropbox.android
-POM_ARTIFACT_ID=filesystem3
+POM_NAME=com.dropbox.mobile.store
+POM_ARTIFACT_ID=filesystem4
 POM_PACKAGING=aar

--- a/multicast/gradle.properties
+++ b/multicast/gradle.properties
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-POM_NAME=com.dropbox.android
+POM_NAME=com.dropbox.mobile.store
 POM_ARTIFACT_ID=multicast
 POM_PACKAGING=jar

--- a/store/gradle.properties
+++ b/store/gradle.properties
@@ -1,4 +1,4 @@
-POM_NAME=com.dropbox.android
-POM_ARTIFACT_ID=store3
+POM_NAME=com.dropbox.mobile.store
+POM_ARTIFACT_ID=store4
 POM_PACKAGING=aar
 android.enableAapt2=false


### PR DESCRIPTION
## Context

PR #11 landed as `408c91d158ee2fd357e2bfc07a57f35dce23a4a1`.
The post-merge Store6 workflow was green (`30046754123`), but root CI
`30046754162` retained two new scheduler-sensitive failures in artifact
`8579592913`:

- `StoreInvalidationConformanceUnderReaderHopTest.invalidateAll_wakesResidentCollector`
  exhausted the conformance helper's nested 5-second wall-clock timeout.
- `OverlayProjectionProtocolTest.foreignDirectOwner_equalButDistinctBaselineIsNeverReused`
  exhausted `projectionDelivery.awaitEntered()` through the internal protocol
  helper's nested 2-second wall-clock timeout.

Both failures were timeout-only: no semantic assertion mismatch or production
exception. Per Plan 017, the red run remains evidence and was not rerun to green.

The first PR #12 head, `c6e45aba0489b82127873c401665390111281eaa`,
then produced:

- green root CI in run `30049100379`;
- four green Store6 jobs and one red Linux build/test job in run
  `30049100256`;
- a third timeout-only failure in artifact `8580434767`:
  `StoreRevalidationConformanceTest.slowCollector_neverLosesPostClearLoadingBeforeRefetchCompletes`
  exhausted the same retained 5-second causal-wait pattern in the byte-identical
  SQLDelight borrowed suite.

That red head remains evidence. It was not rerun unchanged.

## Repair

- Preserve every `Dispatchers.Default` hop that establishes cross-scheduler
  ordering.
- Remove the short nested physical timers from causal deferred, gate, channel,
  reader-delivery, and subscription waits.
- Give the ordinary affected suites one 25-second `runTest` bound so one owner
  controls failure, cancellation, and cleanup.
- Keep the intentional 240-second invalidation-stress watchdog and, with explicit
  approval, raise only the core JS Mocha ceiling from 30 to 300 seconds so
  `runTest` remains the cancellation owner.
- Order timeout-path cleanup as collector cancellation, synchronous Store close,
  then join, so cancellation cannot skip the Store-owned job.
- Change no production, API, Swift, publication, or workflow file.
- Add no retry, filter, quarantine, sleep, or assertion weakening.

## Local verification

- All three retained hosted-failure scenarios: green together and 5/5 serial
  repetitions.
- Core JVM: 59 suites, 517 tests, zero failures/errors/skips.
- Core Android debug: 58 suites, 516 tests, zero failures/errors/skips.
- SQLDelight Android release: 25 suites, 184 tests, zero failures/errors/skips.
- Core macOS arm64: 58 suites, 516 tests, zero failures/errors/skips.
- Core JS Node: 58 suites, 516 tests, zero failures/errors/skips.
- Core Wasm Node: 58 suites, 516 tests, zero failures/errors/skips. Kotlin
  2.1.21 uses `KotlinWasmNode` rather than Mocha for this target, so its
  per-test `runTest` bounds remain authoritative.
- The final JS and Wasm runs disabled configuration-on-demand, validated
  `kotlinStoreYarnLock` normally, and left the tracked lockfile unchanged.
- `apiCheck` and `checkSwiftDumps`: green with zero tracked drift.
- All 10 borrowed conformance files: byte-identical after the SQLDelight build.
- Independent Plan 017 compliance and coroutine/cross-platform quality reviews:
  passed after the complete causal-wait sweep, cancellation-safe cleanup, and
  approved JS runner alignment.

## Hosted gate

Fresh PR-head Store6 and root CI runs must both be green at the new repair head.
After merge, both workflows must also be green at the exact new squash SHA
before Issue 010/017 documentation closeout.
