### PR TITLE
Replace Retrofit's deprecated Deferred CallAdapter with its built-in suspend support.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,5 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$versions.kotlin"
 
     implementation libraries.coroutinesCore
-    implementation 'com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:0.9.2'
     implementation libraries.coroutinesAndroid
 }

--- a/app/src/main/java/com/dropbox/android/sample/Graph.kt
+++ b/app/src/main/java/com/dropbox/android/sample/Graph.kt
@@ -11,7 +11,6 @@ import com.dropbox.android.sample.data.model.Children
 import com.dropbox.android.sample.data.model.Post
 import com.dropbox.android.sample.data.model.RedditDb
 import com.dropbox.android.sample.data.remote.Api
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -28,8 +27,7 @@ object Graph {
         val db = provideRoom(context)
         return StoreBuilder
             .fromNonFlow { key: String ->
-                provideRetrofit().fetchSubreddit(key, "10")
-                    .await().data.children.map(::toPosts)
+                provideRetrofit().fetchSubreddit(key, "10").data.children.map(::toPosts)
             }
             .persister(reader = db.postDao()::loadPosts,
                 writer = db.postDao()::insertPosts,
@@ -54,7 +52,6 @@ object Graph {
         return Retrofit.Builder()
             .baseUrl("https://reddit.com/")
             .addConverterFactory(MoshiConverterFactory.create(provideMoshi()))
-            .addCallAdapterFactory(CoroutineCallAdapterFactory())
             .build()
             .create(Api::class.java)
     }

--- a/app/src/main/java/com/dropbox/android/sample/data/remote/Api.kt
+++ b/app/src/main/java/com/dropbox/android/sample/data/remote/Api.kt
@@ -1,7 +1,6 @@
 package com.dropbox.android.sample.data.remote
 
 import com.dropbox.android.sample.data.model.RedditData
-import kotlinx.coroutines.Deferred
 import okhttp3.ResponseBody
 import retrofit2.http.GET
 import retrofit2.http.Path
@@ -10,14 +9,14 @@ import retrofit2.http.Query
 interface Api {
 
     @GET("r/{subredditName}/new/.json")
-    fun fetchSubreddit(
+    suspend fun fetchSubreddit(
         @Path("subredditName") subredditName: String,
         @Query("limit") limit: String
-    ): Deferred<RedditData>
+    ): RedditData
 
     @GET("r/{subredditName}/new/.json")
-    fun fetchSubredditForPersister(
+    suspend fun fetchSubredditForPersister(
         @Path("subredditName") subredditName: String,
         @Query("limit") limit: String
-    ): Deferred<ResponseBody>
+    ): ResponseBody
 }


### PR DESCRIPTION
The sample app is using the deprecated Retrofit coroutine adapter with Deferred.

It is advised to migrate to Retrofit's built-in suspend support.

More details at https://github.com/JakeWharton/retrofit2-kotlin-coroutines-adapter