### PR TITLE
Fix multiple collections on Multicast

### DIFF
--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/Multicaster.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/Multicaster.kt
@@ -80,28 +80,6 @@ class Multicaster<T>(
         )
     }
 
-    fun create(): Flow<T> {
-        val channel = Channel<ChannelManager.Message.DispatchValue<T>>(Channel.UNLIMITED)
-        return channel.consumeAsFlow()
-            .onStart {
-                channelManager.send(
-                    ChannelManager.Message.AddChannel(
-                        channel
-                    )
-                )
-            }
-            .transform {
-                emit(it.value)
-                it.delivered.complete(Unit)
-            }.onCompletion {
-                channelManager.send(
-                    ChannelManager.Message.RemoveChannel(
-                        channel
-                    )
-                )
-            }
-    }
-
     val flow = flow<T> {
         val channel = Channel<ChannelManager.Message.DispatchValue<T>>(Channel.UNLIMITED)
         val subFlow = channel.consumeAsFlow()

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/InfiniteMulticastTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/InfiniteMulticastTest.kt
@@ -67,19 +67,19 @@ class InfiniteMulticastTest {
             }
         }
         val c1 = async {
-            activeFlow.create().onEach {
+            activeFlow.flow.onEach {
                 delay(100)
             }.take(6).toList()
         }
         val c2 = async {
-            activeFlow.create().onEach {
+            activeFlow.flow.onEach {
                 delay(200)
             }.take(6).toList()
         }
         // ensure first flow finishes
         delay(10_000)
         // add another
-        val c3 = activeFlow.create().take(3).toList()
+        val c3 = activeFlow.flow.take(3).toList()
         assertThat(c1.await())
             .isEqualTo(listOf("a0", "b0", "c0", "a1", "b1", "c1"))
         assertThat(c2.await())
@@ -100,19 +100,19 @@ class InfiniteMulticastTest {
             }
         }
         val c1 = async {
-            activeFlow.create().onEach {
+            activeFlow.flow.onEach {
                 delay(100)
             }.take(6).toList()
         }
         val c2 = async {
-            activeFlow.create().onEach {
+            activeFlow.flow.onEach {
                 delay(200)
             }.take(6).toList()
         }
         // ensure first flow finishes
         delay(10_000)
         // add another
-        val c3 = activeFlow.create().take(1).toList()
+        val c3 = activeFlow.flow.take(1).toList()
         assertThat(c1.await())
             .isEqualTo(listOf("a0", "b0", "c0", "a1", "b1", "c1"))
         assertThat(c2.await())
@@ -133,19 +133,19 @@ class InfiniteMulticastTest {
             }
         }
         val c1 = async {
-            activeFlow.create().onEach {
+            activeFlow.flow.onEach {
                 delay(100)
             }.take(4).toList()
         }
         val c2 = async {
-            activeFlow.create().onEach {
+            activeFlow.flow.onEach {
                 delay(200)
             }.take(5).toList()
         }
         // ensure first flow finishes
         delay(10_000)
         // add another
-        val c3 = activeFlow.create().take(3).toList()
+        val c3 = activeFlow.flow.take(3).toList()
         assertThat(c1.await())
             .isEqualTo(listOf("a0", "b0", "c0", "a1"))
         assertThat(c2.await())
@@ -167,19 +167,19 @@ class InfiniteMulticastTest {
             }
         }
         val c1 = async {
-            activeFlow.create().onEach {
+            activeFlow.flow.onEach {
                 delay(100)
             }.take(4).toList()
         }
         val c2 = async {
-            activeFlow.create().onEach {
+            activeFlow.flow.onEach {
                 delay(200)
             }.take(5).toList()
         }
         // ensure first flow finishes
         delay(10_000)
         // add another
-        val c3 = activeFlow.create().take(1).toList()
+        val c3 = activeFlow.flow.take(1).toList()
         assertThat(c1.await())
             .isEqualTo(listOf("a0", "b0", "c0", "a1"))
         assertThat(c2.await())

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/FetcherController.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/FetcherController.kt
@@ -90,7 +90,7 @@ internal class FetcherController<Key, Input, Output>(
         return flow {
             val fetcher = fetchers.acquire(key)
             try {
-                emitAll(fetcher.create())
+                emitAll(fetcher.flow)
             } finally {
                 fetchers.release(key, fetcher)
             }


### PR DESCRIPTION
Multicast implementation had a bug where the returned flow could
not be collected multiple times as it was using the same channel
it created when  was called.

This PR changes it to create per collection to avoid this issue.

I've also replaced  function with a  field as there
is no reason to keep creating a new one, it can be just a flow

Test: MultiplexTest#multipleCollections
Fixes: #26