### PR TITLE
Clean up ChannelManager's interface to make it easier to add more tests (and add some)

### DIFF
--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/ChannelManager.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/ChannelManager.kt
@@ -19,9 +19,14 @@ package com.dropbox.flow.multicast
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.Flow
 import java.util.ArrayDeque
 import java.util.Collections
+
+// TODO uncomment when [ExperimentalCoroutinesApi] is fixed to support typealias
+// @ExperimentalCoroutinesApi
+internal typealias ChannelManagerInbox<T> = suspend (ChannelManager.Message.Dispatch<T>) -> Unit
 
 /**
  * This actor helps tracking active channels and is able to dispatch values to each of them
@@ -43,170 +48,253 @@ internal class ChannelManager<T>(
      * Instead, it is kept open and if a new downstream shows up that causes us to restart the flow,
      * it will receive values as well.
      */
-    private val piggybackingDownstream: Boolean = false,
+    piggybackingDownstream: Boolean = false,
     /**
      * Called when a value is dispatched
      */
-    private val onEach: suspend (T) -> Unit,
-    /**
-     * Called when the channel manager is active (e.g. it has downstream collectors and needs a
-     * producer)
-     */
-    private val onActive: (ChannelManager<T>) -> SharedFlowProducer<T>
-) : StoreRealActor<ChannelManager.Message<T>>(scope) {
-    private val buffer = Buffer<T>(bufferSize)
-    /**
-     * The current producer
-     */
-    private var producer: SharedFlowProducer<T>? = null
+    onEach: suspend (T) -> Unit,
 
-    /**
-     * Tracks whether we've ever dispatched value or error from the current producer.
-     * Reset when producer finishes.
-     */
-    private var dispatchedValue: Boolean = false
+    upstream: Flow<T>
+) {
 
-    /**
-     * List of downstream collectors.
-     */
-    private val channels = mutableListOf<ChannelEntry<T>>()
+    private val actor = Actor<T>(scope, bufferSize, piggybackingDownstream, onEach, upstream)
 
-    override suspend fun handle(msg: Message<T>) {
-        when (msg) {
-            is Message.AddChannel -> doAdd(msg)
-            is Message.RemoveChannel -> doRemove(msg.channel)
-            is Message.DispatchValue -> doDispatchValue(msg)
-            is Message.DispatchError -> doDispatchError(msg)
-            is Message.UpstreamFinished -> doHandleUpstreamClose(msg.producer)
-        }
+    suspend operator fun plusAssign(channel: SendChannel<Message.Dispatch.Value<T>>) =
+        actor.send(Message.AddChannel(channel))
+
+    suspend operator fun minusAssign(channel: SendChannel<Message.Dispatch.Value<T>>) =
+        actor.send(Message.RemoveChannel(channel))
+
+    suspend fun close() {
+        actor.close()
     }
 
-    /**
-     * We are closing. Do a cleanup on existing channels where we'll close them and also decide
-     * on the list of leftovers.
-     */
-    private fun doHandleUpstreamClose(producer: SharedFlowProducer<T>?) {
-        if (this.producer !== producer) {
-            return
+    private class Actor<T>(
+        /**
+         * The scope in which ChannelManager actor runs
+         */
+        private val scope: CoroutineScope,
+        /**
+         * The buffer size that is used while the upstream is active
+         */
+        private val bufferSize: Int,
+        /**
+         * If true, downstream is never closed by the ChannelManager unless upstream throws an error.
+         * Instead, it is kept open and if a new downstream shows up that causes us to restart the flow,
+         * it will receive values as well.
+         */
+        private val piggybackingDownstream: Boolean = false,
+        /**
+         * Called when a value is dispatched
+         */
+        private val onEach: suspend (T) -> Unit,
+
+        private val upstream: Flow<T>
+    ) : StoreRealActor<Message<T>>(scope) {
+
+        private val buffer = Buffer<T>(bufferSize)
+        /**
+         * The current producer
+         */
+        private var producer: SharedFlowProducer<T>? = null
+
+        /**
+         * Tracks whether we've ever dispatched value or error from the current producer.
+         * Reset when producer finishes.
+         */
+        private var dispatchedValue: Boolean = false
+
+        /**
+         * List of downstream collectors.
+         */
+        private val channels = mutableListOf<ChannelEntry<T>>()
+
+        override suspend fun handle(msg: Message<T>) {
+            when (msg) {
+                is Message.AddChannel -> doAdd(msg)
+                is Message.RemoveChannel -> doRemove(msg.channel)
+                is Message.Dispatch.Value -> doDispatchValue(msg)
+                is Message.Dispatch.Error -> doDispatchError(msg)
+                is Message.Dispatch.UpstreamFinished -> doHandleUpstreamClose(msg.producer)
+            }
         }
-        val piggyBacked = mutableListOf<ChannelEntry<T>>()
-        val leftovers = mutableListOf<ChannelEntry<T>>()
-        channels.forEach {
-            when {
-                it.receivedValue -> {
-                    if (!piggybackingDownstream) {
-                        it.close()
-                    } else {
-                        piggyBacked.add(it)
+
+        override fun onClosed() {
+            channels.forEach {
+                it.close()
+            }
+            channels.clear()
+            producer?.cancel()
+        }
+
+        /**
+         * Called when the channel manager is active (e.g. it has downstream collectors and needs a
+         * producer)
+         */
+        private fun newProducer() = SharedFlowProducer(scope, upstream, ::send)
+
+        /**
+         * We are closing. Do a cleanup on existing channels where we'll close them and also decide
+         * on the list of leftovers.
+         */
+        private fun doHandleUpstreamClose(producer: SharedFlowProducer<T>?) {
+            if (this.producer !== producer) {
+                return
+            }
+            val piggyBacked = mutableListOf<ChannelEntry<T>>()
+            val leftovers = mutableListOf<ChannelEntry<T>>()
+            channels.forEach {
+                when {
+                    it.receivedValue -> {
+                        if (!piggybackingDownstream) {
+                            it.close()
+                        } else {
+                            piggyBacked.add(it)
+                        }
                     }
-                }
-                dispatchedValue ->
-                    // we dispatched a value but this channel didn't receive so put it into
-                    // leftovers
-                    leftovers.add(it)
-                else -> { // upstream didn't dispatch
-                    if (!piggybackingDownstream) {
-                        it.close()
-                    } else {
-                        piggyBacked.add(it)
+                    dispatchedValue ->
+                        // we dispatched a value but this channel didn't receive so put it into
+                        // leftovers
+                        leftovers.add(it)
+                    else -> { // upstream didn't dispatch
+                        if (!piggybackingDownstream) {
+                            it.close()
+                        } else {
+                            piggyBacked.add(it)
+                        }
                     }
                 }
             }
+            channels.clear() // empty references
+            channels.addAll(leftovers)
+            channels.addAll(piggyBacked)
+            this.producer = null
+            // we only reactivate if leftovers is not empty
+            if (leftovers.isNotEmpty()) {
+                activateIfNecessary()
+            }
         }
-        channels.clear() // empty references
-        channels.addAll(leftovers)
-        channels.addAll(piggyBacked)
-        this.producer = null
-        // we only reactivate if leftovers is not empty
-        if (leftovers.isNotEmpty()) {
+
+        /**
+         * Dispatch value to all downstream collectors.
+         */
+        private suspend fun doDispatchValue(msg: Message.Dispatch.Value<T>) {
+            onEach(msg.value)
+            buffer.add(msg)
+            dispatchedValue = true
+            channels.forEach {
+                it.dispatchValue(msg)
+            }
+        }
+
+        /**
+         * Dispatch an upstream error to downstream collectors.
+         */
+        private fun doDispatchError(msg: Message.Dispatch.Error<T>) {
+            // dispatching error is as good as dispatching value
+            dispatchedValue = true
+            channels.forEach {
+                it.dispatchError(msg.error)
+            }
+        }
+
+        /**
+         * Remove a downstream collector.
+         */
+        private suspend fun doRemove(channel: SendChannel<Message.Dispatch.Value<T>>) {
+            val index = channels.indexOfFirst {
+                it.hasChannel(channel)
+            }
+            if (index >= 0) {
+                channels.removeAt(index)
+                if (channels.isEmpty()) {
+                    producer?.cancelAndJoin()
+                }
+            }
+        }
+
+        /**
+         * Add a new downstream collector
+         */
+        private suspend fun doAdd(msg: Message.AddChannel<T>) {
+            addEntry(
+                entry = ChannelEntry(
+                    channel = msg.channel
+                )
+            )
             activateIfNecessary()
         }
-    }
 
-    override fun onClosed() {
-        channels.forEach {
-            it.close()
-        }
-        channels.clear()
-        producer?.cancel()
-    }
-
-    /**
-     * Dispatch value to all downstream collectors.
-     */
-    private suspend fun doDispatchValue(msg: Message.DispatchValue<T>) {
-        onEach(msg.value)
-        buffer.add(msg)
-        dispatchedValue = true
-        channels.forEach {
-            it.dispatchValue(msg)
-        }
-    }
-
-    /**
-     * Dispatch an upstream error to downstream collectors.
-     */
-    private fun doDispatchError(msg: Message.DispatchError<T>) {
-        // dispatching error is as good as dispatching value
-        dispatchedValue = true
-        channels.forEach {
-            it.dispatchError(msg.error)
-        }
-    }
-
-    /**
-     * Remove a downstream collector.
-     */
-    private suspend fun doRemove(channel: Channel<Message.DispatchValue<T>>) {
-        val index = channels.indexOfFirst {
-            it.hasChannel(channel)
-        }
-        if (index >= 0) {
-            channels.removeAt(index)
-            if (channels.isEmpty()) {
-                producer?.cancelAndJoin()
+        private fun activateIfNecessary() {
+            if (producer == null) {
+                producer = newProducer()
+                dispatchedValue = false
+                producer!!.start()
             }
         }
-    }
 
-    /**
-     * Add a new downstream collector
-     */
-    private suspend fun doAdd(msg: Message.AddChannel<T>) {
-        addEntry(
-            entry = ChannelEntry(
-                channel = msg.channel
-            )
-        )
-        activateIfNecessary()
-    }
+        /**
+         * Internally add the new downstream collector to our list, send it anything buffered.
+         */
+        private suspend fun addEntry(entry: ChannelEntry<T>) {
+            val new = channels.none {
+                it.hasChannel(entry)
+            }
+            check(new) {
+                "$entry is already in the list."
+            }
+            check(!entry.receivedValue) {
+                "$entry already received a value"
+            }
+            channels.add(entry)
+            if (buffer.items.isNotEmpty()) {
+                // if there is anything in the buffer, send it
+                buffer.items.forEach {
+                    entry.dispatchValue(it)
+                }
+            }
+        }
 
-    private fun activateIfNecessary() {
-        if (producer == null) {
-            producer = onActive(this)
-            dispatchedValue = false
-            producer!!.start()
+        /**
+         * Buffer implementation for any late arrivals.
+         */
+        private interface Buffer<T> {
+            fun add(item: Message.Dispatch.Value<T>)
+            val items: Collection<Message.Dispatch.Value<T>>
         }
-    }
 
-    /**
-     * Internally add the new downstream collector to our list, send it anything buffered.
-     */
-    private suspend fun addEntry(entry: ChannelEntry<T>) {
-        val new = channels.none {
-            it.hasChannel(entry)
+        /**
+         * Default implementation of buffer which does not buffer anything.
+         */
+        private class NoBuffer<T> : Buffer<T> {
+            override val items: Collection<Message.Dispatch.Value<T>>
+                get() = Collections.emptyList()
+
+            // ignore
+            override fun add(item: Message.Dispatch.Value<T>) = Unit
         }
-        check(new) {
-            "$entry is already in the list."
+
+        /**
+         * Create a new buffer insteance based on the provided limit.
+         */
+        @Suppress("FunctionName")
+        private fun <T> Buffer(limit: Int): Buffer<T> = if (limit > 0) {
+            BufferImpl(limit)
+        } else {
+            NoBuffer()
         }
-        check(!entry.receivedValue) {
-            "$entry already received a value"
-        }
-        channels.add(entry)
-        if (buffer.items.isNotEmpty()) {
-            // if there is anything in the buffer, send it
-            buffer.items.forEach {
-                entry.dispatchValue(it)
+
+        /**
+         * A real buffer implementation that has a FIFO queue.
+         */
+        private class BufferImpl<T>(private val limit: Int) :
+            Buffer<T> {
+            override val items = ArrayDeque<Message.Dispatch.Value<T>>(limit.coerceAtMost(10))
+            override fun add(item: Message.Dispatch.Value<T>) {
+                while (items.size >= limit) {
+                    items.pollFirst()
+                }
+                items.offerLast(item)
             }
         }
     }
@@ -218,7 +306,7 @@ internal class ChannelManager<T>(
         /**
          * The channel used by the collector
          */
-        private val channel: Channel<Message.DispatchValue<T>>,
+        private val channel: SendChannel<Message.Dispatch.Value<T>>,
         /**
          * Tracking whether we've ever dispatched a value or an error to downstream
          */
@@ -227,7 +315,7 @@ internal class ChannelManager<T>(
         val receivedValue
             get() = _receivedValue
 
-        suspend fun dispatchValue(value: Message.DispatchValue<T>) {
+        suspend fun dispatchValue(value: Message.Dispatch.Value<T>) {
             _receivedValue = true
             channel.send(value)
         }
@@ -241,7 +329,7 @@ internal class ChannelManager<T>(
             channel.close()
         }
 
-        fun hasChannel(channel: Channel<Message.DispatchValue<T>>) = this.channel === channel
+        fun hasChannel(channel: SendChannel<Message.Dispatch.Value<T>>) = this.channel === channel
 
         fun hasChannel(entry: ChannelEntry<T>) = this.channel === entry.channel
     }
@@ -254,87 +342,50 @@ internal class ChannelManager<T>(
          * Add a new channel, that means a new downstream subscriber
          */
         class AddChannel<T>(
-            val channel: Channel<DispatchValue<T>>
+            val channel: SendChannel<Dispatch.Value<T>>
         ) : Message<T>()
 
         /**
          * Remove a downstream subscriber, that means it completed
          */
-        class RemoveChannel<T>(val channel: Channel<DispatchValue<T>>) : Message<T>()
+        class RemoveChannel<T>(val channel: SendChannel<Dispatch.Value<T>>) : Message<T>()
 
-        /**
-         * Upstream dispatched a new value, send it to all downstream items
-         */
-        class DispatchValue<T>(
+        sealed class Dispatch<T> : Message<T>() {
             /**
-             * The value dispatched by the upstream
+             * Upstream dispatched a new value, send it to all downstream items
              */
-            val value: T,
+            class Value<T>(
+                /**
+                 * The value dispatched by the upstream
+                 */
+                val value: T,
+                /**
+                 * Ack that is completed by all receiver. Upstream producer will await this before asking
+                 * for a new value from upstream
+                 */
+                val delivered: CompletableDeferred<Unit>
+            ) : Dispatch<T>()
+
             /**
-             * Ack that is completed by all receiver. Upstream producer will await this before asking
-             * for a new value from upstream
+             * Upstream dispatched an error, send it to all downstream items
              */
-            val delivered: CompletableDeferred<Unit>
-        ) : Message<T>()
+            class Error<T>(
+                /**
+                 * The error sent by the upstream
+                 */
+                val error: Throwable
+            ) : Dispatch<T>()
 
-        /**
-         * Upstream dispatched an error, send it to all downstream items
-         */
-        class DispatchError<T>(
-            /**
-             * The error sent by the upstream
-             */
-            val error: Throwable
-        ) : Message<T>()
-
-        class UpstreamFinished<T>(
-            /**
-             * SharedFlowProducer finished emitting
-             */
-            val producer: SharedFlowProducer<T>
-        ) : Message<T>()
-    }
-
-    /**
-     * Buffer implementation for any late arrivals.
-     */
-    private interface Buffer<T> {
-        fun add(item: Message.DispatchValue<T>)
-        val items: Collection<Message.DispatchValue<T>>
-    }
-
-    /**
-     * Default implementation of buffer which does not buffer anything.
-     */
-    private class NoBuffer<T> : Buffer<T> {
-        override val items: Collection<Message.DispatchValue<T>>
-            get() = Collections.emptyList()
-
-        // ignore
-        override fun add(item: Message.DispatchValue<T>) = Unit
-    }
-
-    /**
-     * Create a new buffer insteance based on the provided limit.
-     */
-    @Suppress("FunctionName")
-    private fun <T> Buffer(limit: Int): Buffer<T> = if (limit > 0) {
-        BufferImpl(limit)
-    } else {
-        NoBuffer()
-    }
-
-    /**
-     * A real buffer implementation that has a FIFO queue.
-     */
-    private class BufferImpl<T>(private val limit: Int) :
-        Buffer<T> {
-        override val items = ArrayDeque<Message.DispatchValue<T>>(limit.coerceAtMost(10))
-        override fun add(item: Message.DispatchValue<T>) {
-            while (items.size >= limit) {
-                items.pollFirst()
-            }
-            items.offerLast(item)
+            class UpstreamFinished<T>(
+                /**
+                 * SharedFlowProducer finished emitting
+                 */
+                val producer: SharedFlowProducer<T>
+            ) : Dispatch<T>()
         }
     }
 }
+
+@ExperimentalCoroutinesApi
+internal fun <T> ChannelManager.Message.Dispatch.Value<T>.markDelivered() =
+    delivered.complete(Unit)

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/ChannelManager.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/ChannelManager.kt
@@ -83,10 +83,10 @@ internal class ChannelManager<T>(
         }
     }
 
-    suspend operator fun plusAssign(channel: SendChannel<Message.Dispatch.Value<T>>) =
+    suspend fun addDownstream(channel: SendChannel<Message.Dispatch.Value<T>>) =
         send(Message.AddChannel(channel))
 
-    suspend operator fun minusAssign(channel: SendChannel<Message.Dispatch.Value<T>>) =
+    suspend fun removeDownstream(channel: SendChannel<Message.Dispatch.Value<T>>) =
         send(Message.RemoveChannel(channel))
 
     /**

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/ChannelManager.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/ChannelManager.kt
@@ -24,10 +24,6 @@ import kotlinx.coroutines.flow.Flow
 import java.util.ArrayDeque
 import java.util.Collections
 
-// TODO uncomment when [ExperimentalCoroutinesApi] is fixed to support typealias
-// @ExperimentalCoroutinesApi
-internal typealias ChannelManagerInbox<T> = suspend (ChannelManager.Message.Dispatch<T>) -> Unit
-
 /**
  * This actor helps tracking active channels and is able to dispatch values to each of them
  * in parallel. As soon as one of them receives the value, the ack in the dispatch message is

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/Multicaster.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/Multicaster.kt
@@ -76,13 +76,13 @@ class Multicaster<T>(
         val channel = Channel<ChannelManager.Message.Dispatch.Value<T>>(Channel.UNLIMITED)
         val subFlow = channel.consumeAsFlow()
                 .onStart {
-                    channelManager += channel
+                    channelManager.addDownstream(channel)
                 }
                 .transform {
                     emit(it.value)
                     it.delivered.complete(Unit)
                 }.onCompletion {
-                    channelManager -= channel
+                channelManager.removeDownstream(channel)
                 }
         emitAll(subFlow)
     }

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/SharedFlowProducer.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/SharedFlowProducer.kt
@@ -15,9 +15,6 @@
  */
 package com.dropbox.flow.multicast
 
-import com.dropbox.flow.multicast.ChannelManager.Message.DispatchError
-import com.dropbox.flow.multicast.ChannelManager.Message.DispatchValue
-import com.dropbox.flow.multicast.ChannelManager.Message.UpstreamFinished
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -31,7 +28,7 @@ import kotlinx.coroutines.launch
 
 /**
  * A flow collector that works with a [ChannelManager] to collect values from an upstream flow
- * and dispatch to the [ChannelManager] which then dispatches to downstream collectors.
+ * and dispatch to the [channelManagerInbox] which then dispatches to downstream collectors.
  *
  * They work in sync such that this producer always expects an ack from the [ChannelManager] after
  * sending an event.
@@ -43,7 +40,7 @@ import kotlinx.coroutines.launch
 internal class SharedFlowProducer<T>(
     private val scope: CoroutineScope,
     private val src: Flow<T>,
-    private val channelManager: ChannelManager<T>
+    private val channelManagerInbox: ChannelManagerInbox<T>
 ) {
     private lateinit var collectionJob: Job
 
@@ -57,15 +54,11 @@ internal class SharedFlowProducer<T>(
                 collectionJob = scope.launch {
                     try {
                         src.catch {
-                            channelManager.send(
-                                DispatchError(
-                                    it
-                                )
-                            )
+                            channelManagerInbox(ChannelManager.Message.Dispatch.Error(it))
                         }.collect {
                             val ack = CompletableDeferred<Unit>()
-                            channelManager.send(
-                                DispatchValue(
+                            channelManagerInbox(
+                                ChannelManager.Message.Dispatch.Value(
                                     it,
                                     ack
                                 )
@@ -84,7 +77,7 @@ internal class SharedFlowProducer<T>(
                 // cleanup the channel manager so that downstreams can be closed if they are not
                 // closed already and leftovers can be moved to a new producer if necessary.
                 try {
-                    channelManager.send(UpstreamFinished(this@SharedFlowProducer))
+                    channelManagerInbox(ChannelManager.Message.Dispatch.UpstreamFinished(this@SharedFlowProducer))
                 } catch (closed: ClosedSendChannelException) {
                     // it might close before us, its fine.
                 }

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerLegacyTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerLegacyTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dropbox.flow.multicast
+
+import com.dropbox.flow.multicast.ChannelManager.Message.Dispatch.Value
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@FlowPreview
+@ExperimentalCoroutinesApi
+@RunWith(JUnit4::class)
+class ChannelManagerLegacyTest {
+    private val scope = TestCoroutineScope()
+    private val manager = ChannelManager<String>(
+        scope,
+        0,
+        onEach = {},
+        upstream = flow {
+            suspendCancellableCoroutine<String> {
+                // never end
+            }
+        }
+    )
+    @Test
+    fun simple() = scope.runBlockingTest {
+        val collection = async {
+            val channel = Channel<Value<String>>(Channel.UNLIMITED)
+            try {
+                manager.addDownstream(channel)
+                channel.consumeAsFlow().take(2).toList()
+                    .map { it.value }
+            } finally {
+                manager.removeDownstream(channel)
+            }
+        }
+        val ack1 = CompletableDeferred<Unit>()
+        manager.send(Value("a", ack1))
+
+        val ack2 = CompletableDeferred<Unit>()
+        manager.send(Value("b", ack2))
+        assertThat(collection.await()).isEqualTo(listOf("a", "b"))
+    }
+}

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerTest.kt
@@ -77,7 +77,7 @@ class ChannelManagerTest {
                 downstream.consumeAsFlow()
                     .onEach { it.markDelivered() }
                     .take(2)
-                    .onCompletion { manager.removeDownstream(downstream)}
+                    .onCompletion { manager.removeDownstream(downstream) }
                     .toList()
                     .map { it.value }
             }
@@ -95,7 +95,7 @@ class ChannelManagerTest {
             val collection = async {
                 downstream.consumeAsFlow()
                     .onEach { it.markDelivered() }
-                    .onCompletion { manager.removeDownstream(downstream)}
+                    .onCompletion { manager.removeDownstream(downstream) }
                     .toList()
                     .map { it.value }
             }
@@ -120,7 +120,7 @@ class ChannelManagerTest {
                 downstream1.consumeAsFlow()
                     .onEach { it.markDelivered() }
                     .take(2)
-                    .onCompletion { manager.removeDownstream(downstream1)}
+                    .onCompletion { manager.removeDownstream(downstream1) }
                     .toList()
                     .map { it.value }
             }

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerTest.kt
@@ -15,64 +15,154 @@
  */
 package com.dropbox.flow.multicast
 
-import com.dropbox.flow.multicast.ChannelManager.Message.AddChannel
-import com.dropbox.flow.multicast.ChannelManager.Message.DispatchValue
-import com.dropbox.flow.multicast.ChannelManager.Message.RemoveChannel
-import kotlinx.coroutines.CompletableDeferred
+import com.dropbox.flow.multicast.ChannelManager.Message.Dispatch
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.consumeAsFlow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import java.lang.Exception
 
 @FlowPreview
 @ExperimentalCoroutinesApi
 @RunWith(JUnit4::class)
 class ChannelManagerTest {
     private val scope = TestCoroutineScope()
-    private val manager = ChannelManager<String>(
-            scope,
-            0,
-            onEach = {}
-    ) {
-        SharedFlowProducer(
-                scope, src =
-        flow {
-            suspendCancellableCoroutine<String> {
-                // never end
-            }
-        },
-                channelManager = it
-        )
-    }
+    private val upstream: Channel<String> = Channel(Channel.UNLIMITED)
+    private val manager = ChannelManager(
+        scope,
+        0,
+        onEach = {},
+        upstream = upstream.consumeAsFlow()
+    )
 
     @Test
-    fun simple() = scope.runBlockingTest {
-        val collection = async {
-            val channel = Channel<DispatchValue<String>>(Channel.UNLIMITED)
-            try {
-                manager.send(AddChannel(channel))
-                channel.consumeAsFlow().take(2).toList()
-                    .map { it.value }
-            } finally {
-                manager.send(RemoveChannel(channel))
-            }
-        }
-        val ack1 = CompletableDeferred<Unit>()
-        manager.send(DispatchValue("a", ack1))
+    fun `Given one downstream WHEN two values come in on the upstream THEN two values are consumed`() =
+        scope.runBlockingTest {
+            val downstream = Channel<Dispatch.Value<String>>(Channel.UNLIMITED)
+            manager += downstream
 
-        val ack2 = CompletableDeferred<Unit>()
-        manager.send(DispatchValue("b", ack2))
-        assertThat(collection.await()).isEqualTo(listOf("a", "b"))
-    }
+            val collection = async {
+                try {
+                    downstream.consumeAsFlow()
+                        .onEach { it.markDelivered() }
+                        .take(2)
+                        .toList()
+                        .map { it.value }
+                } finally {
+                    manager -= downstream
+                }
+            }
+            try {
+                upstream.send("a")
+                upstream.send("b")
+                // upstream.close()
+            } catch (e: Throwable) {
+            }
+            assertThat(collection.await()).isEqualTo(listOf("a", "b"))
+        }
+
+    @Test(expected = TestException::class)
+    fun `Given one downstream WHEN upstream errors THEN error is propagated`() =
+        scope.runBlockingTest {
+            val downstream = Channel<Dispatch.Value<String>>(Channel.UNLIMITED)
+            manager += downstream
+
+            val collection = async {
+                try {
+                    downstream.consumeAsFlow()
+                        .onEach { it.markDelivered() }
+                        .take(2)
+                        .toList()
+                        .map { it.value }
+                } finally {
+                    manager -= downstream
+                }
+            }
+            try {
+                upstream.close(TestException())
+            } catch (e: Throwable) {
+            }
+            collection.await()
+        }
+
+    @Test
+    fun `Given one downstream WHEN upstream closes THEN downstream is closed`() =
+        scope.runBlockingTest {
+            val downstream = Channel<Dispatch.Value<String>>(Channel.UNLIMITED)
+            manager += downstream
+
+            val collection = async {
+                try {
+                    downstream.consumeAsFlow()
+                        .onEach { it.markDelivered() }
+                        .toList()
+                        .map { it.value }
+                } finally {
+                    manager -= downstream
+                }
+            }
+            try {
+                upstream.close()
+            } catch (e: Throwable) {
+            }
+            delay(100) // give the upstream a chance to finish.
+            assertThat(collection.isCompleted).isTrue()
+            assertThat(collection.getCompleted()).isEmpty()
+        }
+
+    @Test
+    fun `Given two downstreams WHEN two values come in on the upstream THEN two values are consumed`() =
+        scope.runBlockingTest {
+            val downstream1 = Channel<Dispatch.Value<String>>(Channel.UNLIMITED)
+            val downstream2 = Channel<Dispatch.Value<String>>(Channel.UNLIMITED)
+            manager += downstream1
+            manager += downstream2
+
+            // ack on channel 1
+            val collection1 = async {
+                try {
+                    downstream1.consumeAsFlow()
+                        .onEach { it.markDelivered() }
+                        .take(2)
+                        .toList()
+                        .map { it.value }
+                } finally {
+                    manager -= downstream1
+                }
+            }
+
+            // also consume (without ack) on channel 2 to make sure we got everything.
+            val collection2 = async {
+                try {
+                    downstream2.consumeAsFlow()
+                        .take(2)
+                        .toList()
+                        .map { it.value }
+                } finally {
+                    manager += downstream2
+                }
+            }
+
+            try {
+                upstream.send("a")
+                upstream.send("b")
+                upstream.close()
+            } catch (e: Throwable) {
+            }
+            assertThat(collection1.await()).isEqualTo(listOf("a", "b"))
+            assertThat(collection2.await()).isEqualTo(listOf("a", "b"))
+        }
 }
+
+private class TestException : Exception()

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerTest.kt
@@ -52,14 +52,14 @@ class ChannelManagerTest {
             val collection = async {
                 val downstream = Channel<Dispatch.Value<String>>(Channel.UNLIMITED)
                 try {
-                    manager += downstream
+                    manager.addDownstream(downstream)
                     downstream.consumeAsFlow()
                         .onEach { it.markDelivered() }
                         .take(2)
                         .toList()
                         .map { it.value }
                 } finally {
-                    manager -= downstream
+                    manager.removeDownstream(downstream)
                 }
             }
             try {
@@ -75,7 +75,7 @@ class ChannelManagerTest {
     fun `Given one downstream WHEN upstream errors THEN error is propagated`() =
         scope.runBlockingTest {
             val downstream = Channel<Dispatch.Value<String>>(Channel.UNLIMITED)
-            manager += downstream
+            manager.addDownstream(downstream)
 
             val collection = async {
                 try {
@@ -85,7 +85,7 @@ class ChannelManagerTest {
                         .toList()
                         .map { it.value }
                 } finally {
-                    manager -= downstream
+                    manager.removeDownstream(downstream)
                 }
             }
             try {
@@ -99,7 +99,7 @@ class ChannelManagerTest {
     fun `Given one downstream WHEN upstream closes THEN downstream is closed`() =
         scope.runBlockingTest {
             val downstream = Channel<Dispatch.Value<String>>(Channel.UNLIMITED)
-            manager += downstream
+            manager.addDownstream(downstream)
 
             val collection = async {
                 try {
@@ -108,7 +108,7 @@ class ChannelManagerTest {
                         .toList()
                         .map { it.value }
                 } finally {
-                    manager -= downstream
+                    manager.removeDownstream(downstream)
                 }
             }
             try {
@@ -128,8 +128,8 @@ class ChannelManagerTest {
 
             // ack on channel 1
             val collection1 = async {
-                manager += downstream1
-                manager += downstream2
+                manager.addDownstream(downstream1)
+                manager.addDownstream(downstream2)
                 try {
                     downstream1.consumeAsFlow()
                         .onEach { it.markDelivered() }
@@ -137,7 +137,7 @@ class ChannelManagerTest {
                         .toList()
                         .map { it.value }
                 } finally {
-                    manager -= downstream1
+                    manager.removeDownstream(downstream1)
                 }
             }
 
@@ -149,7 +149,7 @@ class ChannelManagerTest {
                         .toList()
                         .map { it.value }
                 } finally {
-                    manager -= downstream2
+                    manager.removeDownstream(downstream2)
                 }
             }
 

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/FetcherController.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/FetcherController.kt
@@ -63,15 +63,13 @@ internal class FetcherController<Key, Input, Output>(
             Multicaster(
                 scope = scope,
                 bufferSize = 0,
-                source = {
-                    realFetcher(key).map {
-                        StoreResponse.Data(
-                            it,
-                            origin = ResponseOrigin.Fetcher
-                        ) as StoreResponse<Input>
-                    }.catch {
-                        emit(StoreResponse.Error(it, origin = ResponseOrigin.Fetcher))
-                    }
+                source = realFetcher(key).map {
+                    StoreResponse.Data(
+                        it,
+                        origin = ResponseOrigin.Fetcher
+                    ) as StoreResponse<Input>
+                }.catch {
+                    emit(StoreResponse.Error(it, origin = ResponseOrigin.Fetcher))
                 },
                 piggybackingDownstream = enablePiggyback,
                 onEach = { response ->


### PR DESCRIPTION
Main changes:
* ~`ChannelManager` no longer inherits from `StoreRealActor` but rather delegates to one~ (will send in a separate PR).
* messages coming from the upstream were placed under `Message.Dispach` rather than `Message`. These are the only messages accepted from outside`ChannelManager`
* `ChannelManager` now only exposes `plusAsign`, `minusAsign` for adding/removing channels, close for closing  and send(msg, Message.Dispatch) for upstream events
* `SharedFlowProducer` no longer has a back dependency on `ChannelManager`, rather it accepts a `suspend (Message.Dispatch) -> Unit`
* `ChannelManager` is now built with the upstream flow rather than a flow factory. Given that a flow is stateless, passing in a flow that can be re-consumed seems like the simpler API.
* New `ChannelManager` tests