### PR TITLE
Implement Truth and migrate store module

### DIFF
--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -24,6 +24,7 @@ ext.versions = [
         // Testing.
         junit                : '4.12',
         assertJ              : '1.7.1',
+        truth                : '1.0',
         mockito              : '2.24.0',
         mockitoKotlin        : '2.2.0',
         espresso             : '2.2.1',
@@ -58,6 +59,7 @@ ext.libraries = [
         // Testing.
         junit                   : "junit:junit:$versions.junit",
         assertJ                 : "org.assertj:assertj-core:$versions.assertJ",
+        truth                   : "com.google.truth:truth:$versions.truth",
         mockito                 : "org.mockito:mockito-core:$versions.mockito",
         mockitoInline           : "org.mockito:mockito-inline:$versions.mockito",
         mockitoKotlin           : "com.nhaarman.mockitokotlin2:mockito-kotlin:$versions.mockitoKotlin",

--- a/store/build.gradle
+++ b/store/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     testImplementation libraries.mockito
     testImplementation libraries.mockitoInline
     testImplementation libraries.mockitoKotlin
-    testImplementation libraries.assertJ
+    testImplementation libraries.truth
     testImplementation libraries.junit
     testImplementation libraries.coroutinesTest
     testCompileOnly libraries.jsr305

--- a/store/src/test/java/com/dropbox/android/external/store3/ClearStoreMemoryTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/ClearStoreMemoryTest.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized

--- a/store/src/test/java/com/dropbox/android/external/store3/ClearStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/ClearStoreTest.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized

--- a/store/src/test/java/com/dropbox/android/external/store3/NoNetworkTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/NoNetworkTest.kt
@@ -7,8 +7,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.fail
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized

--- a/store/src/test/java/com/dropbox/android/external/store3/SequentialTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/SequentialTest.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized

--- a/store/src/test/java/com/dropbox/android/external/store3/StoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/StoreTest.kt
@@ -19,8 +19,8 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.fail
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized

--- a/store/src/test/java/com/dropbox/android/external/store3/StoreThrowOnNoItems.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/StoreThrowOnNoItems.kt
@@ -10,8 +10,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.fail
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized

--- a/store/src/test/java/com/dropbox/android/external/store3/StreamOneKeyTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/StreamOneKeyTest.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/store/src/test/java/com/dropbox/android/external/store3/base/impl/MemoryPolicyBuilderTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/base/impl/MemoryPolicyBuilderTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 
 import java.util.concurrent.TimeUnit
 
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 
 class MemoryPolicyBuilderTest {
 

--- a/store/src/test/java/com/dropbox/android/external/store4/FetcherControllerTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/FetcherControllerTest.kt
@@ -18,6 +18,7 @@ package com.dropbox.android.external.store4
 import com.dropbox.android.external.store4.ResponseOrigin.Fetcher
 import com.dropbox.android.external.store4.StoreResponse.Data
 import com.dropbox.android.external.store4.impl.FetcherController
+import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
@@ -27,7 +28,6 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4

--- a/store/src/test/java/com/dropbox/android/external/store4/SourceOfTruthWithBarrierTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/SourceOfTruthWithBarrierTest.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 @FlowPreview

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FakeFetcher.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FakeFetcher.kt
@@ -15,7 +15,7 @@
  */
 package com.dropbox.android.external.store4.impl
 
-import org.assertj.core.api.Assertions
+import com.google.common.truth.Truth.assertThat
 
 class FakeFetcher<Key, Output>(
     vararg val responses: Pair<Key, Output>
@@ -27,7 +27,7 @@ class FakeFetcher<Key, Output>(
             throw AssertionError("unexpected fetch request")
         }
         val pair = responses[index++]
-        Assertions.assertThat(pair.first).isEqualTo(key)
+        assertThat(pair.first).isEqualTo(key)
         return pair.second
     }
 }

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowTestExt.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowTestExt.kt
@@ -15,11 +15,11 @@
  */
 package com.dropbox.android.external.store4.impl
 
+import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
-import org.assertj.core.api.Assertions
 
 /**
  * Asserts only the [expected] items by just taking that many from the stream
@@ -28,6 +28,6 @@ import org.assertj.core.api.Assertions
  */
 @ExperimentalCoroutinesApi
 suspend fun <T> Flow<T>.assertItems(vararg expected: T) {
-    Assertions.assertThat(this.take(expected.size).toList())
+    assertThat(this.take(expected.size).toList())
             .isEqualTo(expected.toList())
 }

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/KeyTrackerTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/KeyTrackerTest.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -71,8 +71,9 @@ class KeyTrackerTest {
             subject.invalidate(it)
         }
         scope2.advanceUntilIdle()
-        collections.forEach { (char, deferred) ->
-            assertThat(deferred.isCompleted).`as`("char $char").isTrue()
+
+        collections.forEach { (_, deferred) ->
+            assertThat(deferred.isCompleted).isTrue()
         }
         assertThat(subject.activeKeyCount()).isEqualTo(0)
     }
@@ -93,8 +94,8 @@ class KeyTrackerTest {
         subject.invalidate('b')
         subject.invalidate('c')
         scope2.runCurrent()
-        collections.forEachIndexed { index, collection ->
-            assertThat(collection.isCompleted).`as`("collector $index").isTrue()
+        collections.forEach { collection ->
+            assertThat(collection.isCompleted).isTrue()
         }
         assertThat(subject.activeKeyCount()).isEqualTo(0)
     }

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/SimplePersisterAsFlowableTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/SimplePersisterAsFlowableTest.kt
@@ -26,8 +26,7 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
-import org.assertj.core.api.Assertions
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -39,7 +38,7 @@ class SimplePersisterAsFlowableTest {
     fun testSimple() = testScope.runBlockingTest {
         val (flowable, written) = create("a", "b")
         val read = flowable.flowReader(barcode).take(1).toCollection(mutableListOf())
-        Assertions.assertThat(read).isEqualTo(listOf("a"))
+        assertThat(read).contains("a")
     }
 
     @Test

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/StreamWithoutSourceOfTruthTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/StreamWithoutSourceOfTruthTest.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -72,7 +72,7 @@ class StreamWithoutSourceOfTruthTest(
         )
         println("!")
         assertThat(twoItemsNoRefresh.await()).containsExactly(
-                StoreResponse.Loading(
+                StoreResponse.Loading<String>(
                         origin = ResponseOrigin.Fetcher
                 ),
                 StoreResponse.Data(


### PR DESCRIPTION
As discussed in issue #21, this PR is to implement Truth and migrate the store module's tests. 

To allow a smooth transition and get some feedback first I just converted the tests in the store module and removed AssertJ from store module's dependencies as part of this PR. Next steps would be converting the rest of the modules and removing AssertJ library from the codebase.