### PR TITLE
Properly implement multicast closing

### DIFF
--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/StoreRealActor.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/StoreRealActor.kt
@@ -84,7 +84,6 @@ internal abstract class StoreRealActor<T>(
         } catch (closed: ClosedSendChannelException) {
             // already closed, ignore
         }
-
     }
 
     companion object {

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/StoreRealActor.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/StoreRealActor.kt
@@ -18,6 +18,7 @@ package com.dropbox.flow.multicast
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.actor
 import java.util.concurrent.atomic.AtomicBoolean
@@ -75,10 +76,15 @@ internal abstract class StoreRealActor<T>(
     }
 
     suspend fun close() {
-        // using a custom token to close so that we can gracefully close the downstream
-        inboundChannel.send(CLOSE_TOKEN)
-        // wait until close is done done
-        closeCompleted.await()
+        try {
+            // using a custom token to close so that we can gracefully close the downstream
+            inboundChannel.send(CLOSE_TOKEN)
+            // wait until close is done done
+            closeCompleted.await()
+        } catch (closed: ClosedSendChannelException) {
+            // already closed, ignore
+        }
+
     }
 
     companion object {

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerTest.kt
@@ -142,11 +142,11 @@ class ChannelManagerTest {
         }
 
     @Test
-    fun `Calling close on ChannelManager should close downstream channels when a value is also dispatched`() =
+    fun `GIVEN two downstreams and a dispatched value WHEN ChannelManager is closed THEN it should close downstreams`() =
         assertClosingChannelManager(true)
 
     @Test
-    fun `Calling close on ChannelManager should close downstream channels when no values are dispatched`() =
+    fun `GIVEN two downstreams without a dispatched value WHEN ChannelManager is closed THEN it should close downstreams`() =
         assertClosingChannelManager(false)
 
     private fun assertClosingChannelManager(dispatchValue: Boolean) = scope.runBlockingTest {

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerTest.kt
@@ -16,6 +16,7 @@
 package com.dropbox.flow.multicast
 
 import com.dropbox.flow.multicast.ChannelManager.Message.Dispatch
+import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
@@ -28,12 +29,10 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
-import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import java.lang.Exception
 
 @FlowPreview
 @ExperimentalCoroutinesApi
@@ -140,6 +139,40 @@ class ChannelManagerTest {
 
             assertThat(collection1.await()).isEqualTo(listOf("a", "b"))
             assertThat(collection2.await()).isEqualTo(listOf("a", "b"))
+        }
+
+    @Test
+    fun `Calling close on ChannelManager should close downstream channels when a value is also dispatched`() =
+        assertClosingChannelManager(true)
+
+    @Test
+    fun `Calling close on ChannelManager should close downstream channels when no values are dispatched`() =
+        assertClosingChannelManager(false)
+
+    private fun assertClosingChannelManager(dispatchValue: Boolean) = scope.runBlockingTest {
+        val downstream1 = Channel<Dispatch.Value<String>>(Channel.UNLIMITED)
+        val downstream2 = Channel<Dispatch.Value<String>>(Channel.UNLIMITED)
+        manager.addDownstream(downstream1)
+        manager.addDownstream(downstream2)
+        if (dispatchValue) {
+            upstream.send("a")
+        }
+        manager.close()
+        assertThat(downstream1.isClosedForSend).isTrue()
+        assertThat(downstream2.isClosedForSend).isTrue()
+        // it can be open for receive if and only if we've already sent a value
+        assertThat(downstream1.isClosedForReceive).isEqualTo(!dispatchValue)
+        assertThat(downstream2.isClosedForReceive).isEqualTo(!dispatchValue)
+    }
+
+    @Test
+    fun `Calling close multiple times on ChannelManager should be idempotent`() =
+        scope.runBlockingTest {
+            val downstream = Channel<Dispatch.Value<String>>(Channel.UNLIMITED)
+            manager.addDownstream(downstream)
+            manager.close()
+            manager.close()
+            assertThat(downstream.isClosedForSend).isTrue()
         }
 }
 


### PR DESCRIPTION
This PR defines the behavior of Multicast Flow.
Previously, it could crash if new observers are added to the
multicaster or if it is closed while there is an active
collector. Now, both of these operations complete without
an error. Collecting on a closed multicaster receives 0
values and closes immediately.

Fixes: #45
Test: ChannelManagerTest, MulticastTest

Please see our contributing guidelines (contributing.md) primarily make sure to sign our cla as we cannot accept code externally without a signed cla

https://opensource.dropbox.com/cla/
