### PR TITLE
Switch POM packaging format to jar for cache, filesystem and store modules.

### DIFF
--- a/cache/gradle.properties
+++ b/cache/gradle.properties
@@ -1,3 +1,3 @@
 POM_NAME=com.dropbox.mobile.store
 POM_ARTIFACT_ID=cache4
-POM_PACKAGING=aar
+POM_PACKAGING=jar

--- a/filesystem/gradle.properties
+++ b/filesystem/gradle.properties
@@ -1,3 +1,3 @@
 POM_NAME=com.dropbox.mobile.store
 POM_ARTIFACT_ID=filesystem4
-POM_PACKAGING=aar
+POM_PACKAGING=jar

--- a/store/gradle.properties
+++ b/store/gradle.properties
@@ -1,4 +1,3 @@
 POM_NAME=com.dropbox.mobile.store
 POM_ARTIFACT_ID=store4
-POM_PACKAGING=aar
-android.enableAapt2=false
+POM_PACKAGING=jar


### PR DESCRIPTION
`store`, `cache` and `filesystem` are all pure JVM / Kotlin modules with no Android dependencies. This PR changes the `POM_PACKAGING` from `aar` to `jar` for these modules (`multicast` module is already packaging `jar`).