### PR TITLE
Increment version for 4.0.0-alpha01 release and prep next development version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Change Log
 
 The change log for Store version 1.x can be found [here](https://github.com/NYTimes/Store/blob/develop/CHANGELOG.md).
 
+Version 4.0.0-alpha01 *(2020-01-08)*
+----------------------------
+
+**New Features**
+* Store has been rewritten using Kotlin Coroutines instead of RxJava
 
 Version 3.1.0 *(2018-06-07)*
 ----------------------------

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Maven central artifacts coming soon. For now please build from source or run `./
 ###### Include gradle dependency (as well as MavenCentral Snapshot repo)
 
 ```groovy
-implementation 'com.dropbox.mobile.store:store4:4.0.0-SNAPSHOT'
+implementation 'com.dropbox.mobile.store:store4:4.0.0-alpha01'
 ```
 
 ###### Set the source & target compatibilities to `1.8`
@@ -201,4 +201,4 @@ The above builder is how we recommend working with data on Android. With the abo
 
 ### Artifacts
 
-**CurrentVersion = 4.0.0-SNAPSHOT**
+**CurrentVersion = 4.0.0-alpha01**

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ allprojects {
 ext {
     // POM file
     GROUP = "com.dropbox.mobile.store"
-    VERSION_NAME = "4.0.0-SNAPSHOT"
+    VERSION_NAME = "4.0.0-alpha01"
     POM_PACKAGING = "pom"
     POM_DESCRIPTION = "Store4 is built with Kotlin Coroutines"
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ allprojects {
 ext {
     // POM file
     GROUP = "com.dropbox.mobile.store"
-    VERSION_NAME = "4.0.0-alpha02-SNAPSHOT"
+    VERSION_NAME = "4.0.0-SNAPSHOT"
     POM_PACKAGING = "pom"
     POM_DESCRIPTION = "Store4 is built with Kotlin Coroutines"
 
@@ -89,5 +89,4 @@ subprojects {
     project.plugins.withType(com.android.build.gradle.AppPlugin).whenPluginAdded(preDexClosure)
     project.plugins.withType(com.android.build.gradle.LibraryPlugin).whenPluginAdded(preDexClosure)
 }
-
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ allprojects {
 ext {
     // POM file
     GROUP = "com.dropbox.mobile.store"
-    VERSION_NAME = "4.0.0-alpha01"
+    VERSION_NAME = "4.0.0-alpha02-SNAPSHOT"
     POM_PACKAGING = "pom"
     POM_DESCRIPTION = "Store4 is built with Kotlin Coroutines"
 


### PR DESCRIPTION
First commit bumps version to 4.0.0-alpha01. I staged the artifact on Sonatype with this version. Next commit just bumps version to next development version 4.0.0-alpha02-SNAPSHOT.