### PR TITLE
Change flow collection util to drain the flow

### DIFF
--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
@@ -56,9 +56,8 @@ class FlowStoreTest {
             nonFlowingFetcher = fetcher::fetch,
             enableCache = true
         )
-        pipeline.stream(StoreRequest.cached(3, refresh = false))
-            .assertItems(
-                testScope,
+        assertThat(pipeline.stream(StoreRequest.cached(3, refresh = false)))
+            .emitsExactly(
                 Loading(
                     origin = Fetcher
                 ), Data(
@@ -66,18 +65,17 @@ class FlowStoreTest {
                     origin = Fetcher
                 )
             )
-        pipeline.stream(StoreRequest.cached(3, refresh = false))
-            .take(1) // TODO remove when Issue #59 is fixed.
-            .assertItems(
-                testScope,
-                Data(
-                    value = "three-1",
-                    origin = Cache
-                )
+        assertThat(
+            pipeline.stream(StoreRequest.cached(3, refresh = false))
+                .take(1) // TODO remove when Issue #59 is fixed.
+        ).emitsExactly(
+            Data(
+                value = "three-1",
+                origin = Cache
             )
-        pipeline.stream(StoreRequest.fresh(3))
-            .assertItems(
-                testScope,
+        )
+        assertThat(pipeline.stream(StoreRequest.fresh(3)))
+            .emitsExactly(
                 Loading(
                     origin = Fetcher
                 ),
@@ -86,10 +84,11 @@ class FlowStoreTest {
                     origin = Fetcher
                 )
             )
-        pipeline.stream(StoreRequest.cached(3, refresh = false))
-            .take(1) // TODO remove when Issue #59 is fixed.
-            .assertItems(
-                testScope,
+        assertThat(
+            pipeline.stream(StoreRequest.cached(3, refresh = false))
+                .take(1) // TODO remove when Issue #59 is fixed.
+        )
+            .emitsExactly(
                 Data(
                     value = "three-2",
                     origin = Cache
@@ -110,9 +109,8 @@ class FlowStoreTest {
             persisterWriter = persister::write,
             enableCache = true
         )
-        pipeline.stream(StoreRequest.cached(3, refresh = false))
-            .assertItems(
-                testScope,
+        assertThat(pipeline.stream(StoreRequest.cached(3, refresh = false)))
+            .emitsExactly(
                 Loading(
                     origin = Fetcher
                 ),
@@ -121,21 +119,22 @@ class FlowStoreTest {
                     origin = Fetcher
                 )
             )
-        pipeline.stream(StoreRequest.cached(3, refresh = false))
-            .assertItems(
-                testScope,
+        assertThat(pipeline.stream(StoreRequest.cached(3, refresh = false)))
+            .emitsExactly(
                 Data(
                     value = "three-1",
                     origin = Cache
                 ),
+                // note that we still get the data from persister as well as we don't listen to
+                // the persister for the cached items unless there is an active stream, which
+                // means cache can go out of sync w/ the persister
                 Data(
                     value = "three-1",
                     origin = Persister
                 )
             )
-        pipeline.stream(StoreRequest.fresh(3))
-            .assertItems(
-                testScope,
+        assertThat(pipeline.stream(StoreRequest.fresh(3)))
+            .emitsExactly(
                 Loading(
                     origin = Fetcher
                 ),
@@ -144,9 +143,8 @@ class FlowStoreTest {
                     origin = Fetcher
                 )
             )
-        pipeline.stream(StoreRequest.cached(3, refresh = false))
-            .assertItems(
-                testScope,
+        assertThat(pipeline.stream(StoreRequest.cached(3, refresh = false)))
+            .emitsExactly(
                 Data(
                     value = "three-2",
                     origin = Cache
@@ -173,9 +171,8 @@ class FlowStoreTest {
             enableCache = true
         )
 
-        pipeline.stream(StoreRequest.cached(3, refresh = true))
-            .assertItems(
-                testScope,
+        assertThat(pipeline.stream(StoreRequest.cached(3, refresh = true)))
+            .emitsExactly(
                 Loading(
                     origin = Fetcher
                 ),
@@ -185,9 +182,8 @@ class FlowStoreTest {
                 )
             )
 
-        pipeline.stream(StoreRequest.cached(3, refresh = true))
-            .assertItems(
-                testScope,
+        assertThat(pipeline.stream(StoreRequest.cached(3, refresh = true)))
+            .emitsExactly(
                 Data(
                     value = "three-1",
                     origin = Cache
@@ -217,9 +213,8 @@ class FlowStoreTest {
             enableCache = true
         )
 
-        pipeline.stream(StoreRequest.cached(3, refresh = true))
-            .assertItems(
-                testScope,
+        assertThat(pipeline.stream(StoreRequest.cached(3, refresh = true)))
+            .emitsExactly(
                 Loading(
                     origin = Fetcher
                 ),
@@ -229,9 +224,8 @@ class FlowStoreTest {
                 )
             )
 
-        pipeline.stream(StoreRequest.cached(3, refresh = true))
-            .assertItems(
-                testScope,
+        assertThat(pipeline.stream(StoreRequest.cached(3, refresh = true)))
+            .emitsExactly(
                 Data(
                     value = "three-1",
                     origin = Cache
@@ -257,9 +251,8 @@ class FlowStoreTest {
             enableCache = true
         )
 
-        pipeline.stream(StoreRequest.skipMemory(3, refresh = false))
-            .assertItems(
-                testScope,
+        assertThat(pipeline.stream(StoreRequest.skipMemory(3, refresh = false)))
+            .emitsExactly(
                 Loading(
                     origin = Fetcher
                 ),
@@ -269,9 +262,8 @@ class FlowStoreTest {
                 )
             )
 
-        pipeline.stream(StoreRequest.skipMemory(3, refresh = false))
-            .assertItems(
-                testScope,
+        assertThat(pipeline.stream(StoreRequest.skipMemory(3, refresh = false)))
+            .emitsExactly(
                 Loading(
                     origin = Fetcher
                 ),
@@ -297,9 +289,8 @@ class FlowStoreTest {
             enableCache = false
         )
 
-        pipeline.stream(StoreRequest.fresh(3))
-            .assertItems(
-                testScope,
+        assertThat(pipeline.stream(StoreRequest.fresh(3)))
+            .emitsExactly(
                 Loading(
                     origin = Fetcher
                 ),
@@ -312,9 +303,8 @@ class FlowStoreTest {
                     origin = Fetcher
                 )
             )
-        pipeline.stream(StoreRequest.cached(3, refresh = true))
-            .assertItems(
-                testScope,
+        assertThat(pipeline.stream(StoreRequest.cached(3, refresh = true)))
+            .emitsExactly(
                 Data(
                     value = "three-2",
                     origin = Persister
@@ -350,10 +340,8 @@ class FlowStoreTest {
             delay(10)
             persister.flowWriter(3, "local-1")
         }
-        pipeline
-            .stream(StoreRequest.cached(3, refresh = true))
-            .assertItems(
-                testScope,
+        assertThat(pipeline.stream(StoreRequest.cached(3, refresh = true)))
+            .emitsExactly(
                 Loading(
                     origin = Fetcher
                 ),
@@ -386,10 +374,8 @@ class FlowStoreTest {
             delay(10) // go in between two server requests
             persister.flowWriter(3, "local-2")
         }
-        pipeline
-            .stream(StoreRequest.cached(3, refresh = true))
-            .assertItems(
-                testScope,
+        assertThat(pipeline.stream(StoreRequest.cached(3, refresh = true)))
+            .emitsExactly(
                 Loading(
                     origin = Fetcher
                 ),
@@ -428,9 +414,8 @@ class FlowStoreTest {
             delay(10)
             persister.flowWriter(3, "local-1")
         }
-        pipeline.stream(StoreRequest.cached(key = 3, refresh = true))
-            .assertItems(
-                testScope,
+        assertThat(pipeline.stream(StoreRequest.cached(key = 3, refresh = true)))
+            .emitsExactly(
                 Loading(
                     origin = Fetcher
                 ),
@@ -443,9 +428,8 @@ class FlowStoreTest {
                     origin = Persister
                 )
             )
-        pipeline.stream(StoreRequest.cached(key = 3, refresh = true))
-            .assertItems(
-                testScope,
+        assertThat(pipeline.stream(StoreRequest.cached(key = 3, refresh = true)))
+            .emitsExactly(
                 Data(
                     value = "local-1",
                     origin = Persister
@@ -467,12 +451,6 @@ class FlowStoreTest {
         StoreRequest.cached(
             key = key,
             refresh = false
-        )
-    )
-
-    suspend fun Store<Int, String>.fresh(key: Int) = get(
-        StoreRequest.fresh(
-            key = key
         )
     )
 

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
@@ -15,9 +15,9 @@
  */
 package com.dropbox.android.external.store4.impl
 
-import com.dropbox.android.external.store4.ResponseOrigin
 import com.dropbox.android.external.store4.ResponseOrigin.Cache
 import com.dropbox.android.external.store4.ResponseOrigin.Fetcher
+import com.dropbox.android.external.store4.ResponseOrigin.Persister
 import com.dropbox.android.external.store4.Store
 import com.dropbox.android.external.store4.StoreBuilder
 import com.dropbox.android.external.store4.StoreRequest
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
@@ -57,6 +58,7 @@ class FlowStoreTest {
         )
         pipeline.stream(StoreRequest.cached(3, refresh = false))
             .assertItems(
+                testScope,
                 Loading(
                     origin = Fetcher
                 ), Data(
@@ -65,7 +67,9 @@ class FlowStoreTest {
                 )
             )
         pipeline.stream(StoreRequest.cached(3, refresh = false))
+            .take(1) // TODO remove when Issue #59 is fixed.
             .assertItems(
+                testScope,
                 Data(
                     value = "three-1",
                     origin = Cache
@@ -73,6 +77,7 @@ class FlowStoreTest {
             )
         pipeline.stream(StoreRequest.fresh(3))
             .assertItems(
+                testScope,
                 Loading(
                     origin = Fetcher
                 ),
@@ -82,7 +87,9 @@ class FlowStoreTest {
                 )
             )
         pipeline.stream(StoreRequest.cached(3, refresh = false))
+            .take(1) // TODO remove when Issue #59 is fixed.
             .assertItems(
+                testScope,
                 Data(
                     value = "three-2",
                     origin = Cache
@@ -105,6 +112,7 @@ class FlowStoreTest {
         )
         pipeline.stream(StoreRequest.cached(3, refresh = false))
             .assertItems(
+                testScope,
                 Loading(
                     origin = Fetcher
                 ),
@@ -115,13 +123,19 @@ class FlowStoreTest {
             )
         pipeline.stream(StoreRequest.cached(3, refresh = false))
             .assertItems(
+                testScope,
                 Data(
                     value = "three-1",
                     origin = Cache
+                ),
+                Data(
+                    value = "three-1",
+                    origin = Persister
                 )
             )
         pipeline.stream(StoreRequest.fresh(3))
             .assertItems(
+                testScope,
                 Loading(
                     origin = Fetcher
                 ),
@@ -132,9 +146,14 @@ class FlowStoreTest {
             )
         pipeline.stream(StoreRequest.cached(3, refresh = false))
             .assertItems(
+                testScope,
                 Data(
                     value = "three-2",
                     origin = Cache
+                ),
+                Data(
+                    value = "three-2",
+                    origin = Persister
                 )
             )
     }
@@ -156,6 +175,7 @@ class FlowStoreTest {
 
         pipeline.stream(StoreRequest.cached(3, refresh = true))
             .assertItems(
+                testScope,
                 Loading(
                     origin = Fetcher
                 ),
@@ -167,13 +187,14 @@ class FlowStoreTest {
 
         pipeline.stream(StoreRequest.cached(3, refresh = true))
             .assertItems(
+                testScope,
                 Data(
                     value = "three-1",
                     origin = Cache
                 ),
                 Data(
                     value = "three-1",
-                    origin = ResponseOrigin.Persister
+                    origin = Persister
                 ),
                 Loading(
                     origin = Fetcher
@@ -198,6 +219,7 @@ class FlowStoreTest {
 
         pipeline.stream(StoreRequest.cached(3, refresh = true))
             .assertItems(
+                testScope,
                 Loading(
                     origin = Fetcher
                 ),
@@ -209,6 +231,7 @@ class FlowStoreTest {
 
         pipeline.stream(StoreRequest.cached(3, refresh = true))
             .assertItems(
+                testScope,
                 Data(
                     value = "three-1",
                     origin = Cache
@@ -236,6 +259,7 @@ class FlowStoreTest {
 
         pipeline.stream(StoreRequest.skipMemory(3, refresh = false))
             .assertItems(
+                testScope,
                 Loading(
                     origin = Fetcher
                 ),
@@ -247,6 +271,7 @@ class FlowStoreTest {
 
         pipeline.stream(StoreRequest.skipMemory(3, refresh = false))
             .assertItems(
+                testScope,
                 Loading(
                     origin = Fetcher
                 ),
@@ -274,6 +299,7 @@ class FlowStoreTest {
 
         pipeline.stream(StoreRequest.fresh(3))
             .assertItems(
+                testScope,
                 Loading(
                     origin = Fetcher
                 ),
@@ -288,9 +314,10 @@ class FlowStoreTest {
             )
         pipeline.stream(StoreRequest.cached(3, refresh = true))
             .assertItems(
+                testScope,
                 Data(
                     value = "three-2",
-                    origin = ResponseOrigin.Persister
+                    origin = Persister
                 ),
                 Loading(
                     origin = Fetcher
@@ -326,12 +353,13 @@ class FlowStoreTest {
         pipeline
             .stream(StoreRequest.cached(3, refresh = true))
             .assertItems(
+                testScope,
                 Loading(
                     origin = Fetcher
                 ),
                 Data(
                     value = "local-1",
-                    origin = ResponseOrigin.Persister
+                    origin = Persister
                 )
             )
     }
@@ -361,12 +389,13 @@ class FlowStoreTest {
         pipeline
             .stream(StoreRequest.cached(3, refresh = true))
             .assertItems(
+                testScope,
                 Loading(
                     origin = Fetcher
                 ),
                 Data(
                     value = "local-1",
-                    origin = ResponseOrigin.Persister
+                    origin = Persister
                 ),
                 Data(
                     value = "three-1",
@@ -374,7 +403,7 @@ class FlowStoreTest {
                 ),
                 Data(
                     value = "local-2",
-                    origin = ResponseOrigin.Persister
+                    origin = Persister
                 ),
                 Data(
                     value = "three-2",
@@ -401,6 +430,7 @@ class FlowStoreTest {
         }
         pipeline.stream(StoreRequest.cached(key = 3, refresh = true))
             .assertItems(
+                testScope,
                 Loading(
                     origin = Fetcher
                 ),
@@ -410,14 +440,15 @@ class FlowStoreTest {
                 ),
                 Data(
                     value = "local-1",
-                    origin = ResponseOrigin.Persister
+                    origin = Persister
                 )
             )
         pipeline.stream(StoreRequest.cached(key = 3, refresh = true))
             .assertItems(
+                testScope,
                 Data(
                     value = "local-1",
-                    origin = ResponseOrigin.Persister
+                    origin = Persister
                 ),
                 Loading(
                     origin = Fetcher

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowSubjectTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowSubjectTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dropbox.android.external.store4.impl
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+@UseExperimental(ExperimentalCoroutinesApi::class)
+class FlowSubjectTest {
+    // Can't use ExpectFailure in these tests because it is not a suspend function.
+    private val testScope = TestCoroutineScope()
+
+    @Test
+    fun exactFlow() = testScope.runBlockingTest {
+        val src = flowOf(1, 2, 3)
+        assertThat(src).emitsExactly(1, 2, 3)
+    }
+
+    @Test
+    fun lessThanExpectedItems() = testScope.runBlockingTest {
+        val src = flowOf(1, 2, 3)
+        val exception = try {
+            assertThat(src).emitsExactly(1, 2, 3, 4)
+            null
+        } catch (error: Throwable) {
+            error
+        }
+        assertThat(exception).hasMessageThat().contains(
+            """
+                    Flow didn't exactly emit expected items
+                    missing (1): 4
+                    ---
+                    expected   : [1, 2, 3, 4]
+                    but was    : [1, 2, 3]
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun outOfOrder() = testScope.runBlockingTest {
+        val src = flowOf(1, 3, 2)
+        val exception = try {
+            assertThat(src).emitsExactly(1, 2, 3)
+            null
+        } catch (error: Throwable) {
+            error
+        }
+        assertThat(exception).hasMessageThat().contains(
+            """
+            Flow didn't exactly emit expected items
+            contents match, but order was wrong
+            expected: [1, 2, 3]
+            but was : [1, 3, 2]
+            """.trimIndent()
+        )
+
+    }
+
+    @Test
+    fun moreThanExpectedItems() = testScope.runBlockingTest {
+        val src = flowOf(1, 2, 3, 4)
+        val exception = try {
+            assertThat(src).emitsExactly(1, 2, 3)
+            null
+        } catch (error: Throwable) {
+            error
+        }
+        assertThat(exception).hasMessageThat().contains(
+            """
+            Too many emissions in the flow
+            expected: [1, 2, 3]
+            but was : [1, 2, 3, 4]
+        """.trimIndent()
+        )
+    }
+}

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowSubjectTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowSubjectTest.kt
@@ -88,7 +88,7 @@ class FlowSubjectTest {
         }
         assertThat(exception).hasMessageThat().contains(
             """
-            Too many emissions in the flow
+            Too many emissions in the flow (only first additional item is shown)
             expected: [1, 2, 3]
             but was : [1, 2, 3, 4]
         """.trimIndent()

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowSubjectTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowSubjectTest.kt
@@ -18,7 +18,10 @@ package com.dropbox.android.external.store4.impl
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
@@ -34,6 +37,16 @@ class FlowSubjectTest {
     @Test
     fun exactFlow() = testScope.runBlockingTest {
         val src = flowOf(1, 2, 3)
+        assertThat(src).emitsExactly(1, 2, 3)
+    }
+
+    @Test
+    fun exactFlow_neverEnding() = testScope.runBlockingTest {
+        val src = flow {
+            emitAll(flowOf(1, 2, 3))
+            // suspend forever
+            suspendCancellableCoroutine<Unit> { }
+        }
         assertThat(src).emitsExactly(1, 2, 3)
     }
 

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowSubjectTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowSubjectTest.kt
@@ -74,7 +74,6 @@ class FlowSubjectTest {
             but was : [1, 3, 2]
             """.trimIndent()
         )
-
     }
 
     @Test

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowTestExt.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowTestExt.kt
@@ -49,7 +49,7 @@ internal class FlowSubject<T> constructor(
             actual.collect {
                 collectedSoFar.add(it)
                 if (collectedSoFar.size > expected.size) {
-                    assertWithMessage("Too many emissions in the flow")
+                    assertWithMessage("Too many emissions in the flow (only first additional item is shown)")
                         .that(collectedSoFar)
                         .isEqualTo(expected)
                 }

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowTestExt.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowTestExt.kt
@@ -17,11 +17,8 @@ package com.dropbox.android.external.store4.impl
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineScope
 
@@ -33,7 +30,7 @@ import kotlinx.coroutines.test.TestCoroutineScope
  * dispatched.
  */
 @ExperimentalCoroutinesApi
-suspend fun <T> Flow<T>.assertItems(scope:TestCoroutineScope, vararg expected: T) {
+suspend fun <T> Flow<T>.assertItems(scope: TestCoroutineScope, vararg expected: T) {
     val collectedSoFar = mutableListOf<T>()
     val collectJob = scope.launch {
         this@assertItems.collect {

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowTestExt.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowTestExt.kt
@@ -21,6 +21,7 @@ import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertWithMessage
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.test.TestCoroutineScope
@@ -56,10 +57,12 @@ internal class FlowSubject<T> constructor(
             }
         }
         testCoroutineScope.advanceUntilIdle()
-        collectionCoroutine.getCompletionExceptionOrNull()?.let {
-            throw it
+        if (!collectionCoroutine.isActive) {
+            collectionCoroutine.getCompletionExceptionOrNull()?.let {
+                throw it
+            }
         }
-        collectionCoroutine.cancel()
+        collectionCoroutine.cancelAndJoin()
         assertWithMessage("Flow didn't exactly emit expected items")
             .that(collectedSoFar)
             .isEqualTo(expected.toList())

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/StreamWithoutSourceOfTruthTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/StreamWithoutSourceOfTruthTest.kt
@@ -61,8 +61,7 @@ class StreamWithoutSourceOfTruthTest(
             ).take(3).toList()
         }
         delay(1_000) // make sure the async block starts first
-        pipeline.stream(StoreRequest.fresh(3)).assertItems(
-            testScope,
+        assertThat(pipeline.stream(StoreRequest.fresh(3))).emitsExactly(
             StoreResponse.Loading(
                 origin = ResponseOrigin.Fetcher
             ),

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/StreamWithoutSourceOfTruthTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/StreamWithoutSourceOfTruthTest.kt
@@ -19,6 +19,7 @@ import com.dropbox.android.external.store4.ResponseOrigin
 import com.dropbox.android.external.store4.StoreBuilder
 import com.dropbox.android.external.store4.StoreRequest
 import com.dropbox.android.external.store4.StoreResponse
+import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
@@ -27,7 +28,6 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
-import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -43,46 +43,47 @@ class StreamWithoutSourceOfTruthTest(
     @Test
     fun streamWithoutPersister() = testScope.runBlockingTest {
         val fetcher = FakeFetcher(
-                3 to "three-1",
-                3 to "three-2"
+            3 to "three-1",
+            3 to "three-2"
         )
         val pipeline = StoreBuilder.fromNonFlow(fetcher::fetch)
-                .scope(testScope)
-                .let {
-                    if (enableCache) {
-                        it
-                    } else {
-                        it.disableCache()
-                    }
-                }.build()
+            .scope(testScope)
+            .let {
+                if (enableCache) {
+                    it
+                } else {
+                    it.disableCache()
+                }
+            }.build()
         val twoItemsNoRefresh = async {
             pipeline.stream(
-                    StoreRequest.cached(3, refresh = false)
+                StoreRequest.cached(3, refresh = false)
             ).take(3).toList()
         }
         delay(1_000) // make sure the async block starts first
         pipeline.stream(StoreRequest.fresh(3)).assertItems(
-                StoreResponse.Loading(
-                        origin = ResponseOrigin.Fetcher
-                ),
-                StoreResponse.Data(
-                        value = "three-2",
-                        origin = ResponseOrigin.Fetcher
-                )
+            testScope,
+            StoreResponse.Loading(
+                origin = ResponseOrigin.Fetcher
+            ),
+            StoreResponse.Data(
+                value = "three-2",
+                origin = ResponseOrigin.Fetcher
+            )
         )
         println("!")
         assertThat(twoItemsNoRefresh.await()).containsExactly(
-                StoreResponse.Loading<String>(
-                        origin = ResponseOrigin.Fetcher
-                ),
-                StoreResponse.Data(
-                        value = "three-1",
-                        origin = ResponseOrigin.Fetcher
-                ),
-                StoreResponse.Data(
-                        value = "three-2",
-                        origin = ResponseOrigin.Fetcher
-                )
+            StoreResponse.Loading<String>(
+                origin = ResponseOrigin.Fetcher
+            ),
+            StoreResponse.Data(
+                value = "three-1",
+                origin = ResponseOrigin.Fetcher
+            ),
+            StoreResponse.Data(
+                value = "three-2",
+                origin = ResponseOrigin.Fetcher
+            )
         )
     }
 


### PR DESCRIPTION
This PR changes the assertItems util method in tests to drain the
flow to ensure we don't produce unwated items.

Please see our contributing guidelines (contributing.md) primarily make sure to sign our cla as we cannot accept code externally without a signed cla

https://opensource.dropbox.com/cla/
