### PR TITLE
Avoid illegal cast in RealStore.stream

### DIFF
--- a/store/src/main/java/com/dropbox/android/external/store4/StoreResponse.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/StoreResponse.kt
@@ -84,7 +84,7 @@ sealed class StoreResponse<out T> {
     internal fun <R> swapType(): StoreResponse<R> = when (this) {
         is Error -> Error(error, origin)
         is Loading -> Loading(origin)
-        is Data -> throw IllegalStateException("cannot swap type for $this")
+        is Data -> throw IllegalStateException("cannot swap type for StoreResponse.Data")
     }
 }
 

--- a/store/src/main/java/com/dropbox/android/external/store4/StoreResponse.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/StoreResponse.kt
@@ -108,12 +108,3 @@ enum class ResponseOrigin {
      */
     Fetcher
 }
-
-// @Suppress("UNCHECKED_CAST")
-// internal fun <Input> Flow<StoreResponse<Input>>.hideData(): Flow<StoreResponse<Unit>> = map {
-//     when (it) {
-//         is StoreResponse.Error -> StoreResponse.Error<Unit>(it.error, it.origin)
-//         is StoreResponse.Loading -> StoreResponse.Loading(it.origin)
-//         is StoreResponse.Data -> StoreResponse.Data(value = Unit, origin = it.origin)
-//     }
-// }

--- a/store/src/main/java/com/dropbox/android/external/store4/StoreResponse.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/StoreResponse.kt
@@ -15,9 +15,6 @@
  */
 package com.dropbox.android.external.store4
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
-
 /**
  * Holder for responses from Store.
  *
@@ -25,7 +22,7 @@ import kotlinx.coroutines.flow.map
  * class to represent each response. This allows the flow to keep running even if an error happens
  * so that if there is an observable single source of truth, application can keep observing it.
  */
-sealed class StoreResponse< out T> {
+sealed class StoreResponse<out T> {
     /**
      * Represents the source of the Response.
      */

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.transform

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
@@ -151,11 +151,11 @@ internal class RealStore<Key : Any, Input : Any, Output : Any>(
             .transform {
                 // left is Fetcher while right is source of truth
                 if (it is Either.Left) {
-                    if (it.value !is StoreResponse.Data<*>) {
+                    if (it.value !is StoreResponse.Data) {
                         emit(it.value.swapType())
                     }
                     // network sent something
-                    if (it.value is StoreResponse.Data<*>) {
+                    if (it.value is StoreResponse.Data) {
                         // unlocking disk only if network sent data so that fresh data request never
                         // receives disk data by mistake
                         diskLock.complete(Unit)


### PR DESCRIPTION
By calling `StoreResponse.swapType` always on when creating a network flow we were always casting `Input` type to `Output`.

When there's no `sourceOfTruth` this isn't a problem as `Input == Output`
Where there's a `sourceOfTruth` then we do an illegal cast (which doesn't crash due to type erasure) then we avoid actually crashing (by attempting to access an instance of `Input` as an `Output` object) because we filter out  inside `networkFlow.merge(diskFlow)`

While this currently does not crash it's pretty easy to see code changes in the future exposing the illegally casted network element and trying to access it (e.g logging).

Change `createNetworkFlow` to return the correct type `Flow<StoreResponse<Input>>` and perform the typecasting when actually using the return type to fix this