### PR TITLE
Fix default MemoryPolicy.

### DIFF
--- a/store/src/main/java/com/dropbox/android/external/store4/MemoryPolicy.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/MemoryPolicy.kt
@@ -17,16 +17,10 @@ class MemoryPolicy internal constructor(
     val expireAfterWrite: Long,
     val expireAfterAccess: Long,
     val expireAfterTimeUnit: TimeUnit,
-    private val maxSizeNotDefault: Long
+    val maxSize: Long
 ) {
 
     val isDefaultWritePolicy: Boolean = expireAfterWrite == DEFAULT_POLICY
-
-    val isDefaultAccessPolicy: Boolean = expireAfterAccess == DEFAULT_POLICY
-
-    val isDefaultMaxSize: Boolean = maxSizeNotDefault == DEFAULT_POLICY
-
-    val maxSize: Long = if (isDefaultMaxSize) 1 else maxSizeNotDefault
 
     val hasWritePolicy: Boolean = expireAfterWrite != DEFAULT_POLICY
 
@@ -73,7 +67,7 @@ class MemoryPolicy internal constructor(
             expireAfterWrite = expireAfterWrite,
             expireAfterAccess = expireAfterAccess,
             expireAfterTimeUnit = expireAfterTimeUnit,
-            maxSizeNotDefault = maxSize
+            maxSize = maxSize
         )
     }
 

--- a/store/src/test/java/com/dropbox/android/external/store3/base/impl/MemoryPolicyBuilderTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/base/impl/MemoryPolicyBuilderTest.kt
@@ -57,6 +57,7 @@ class MemoryPolicyBuilderTest {
                 .setMemorySize(10L)
                 .build()
 
+        assertThat(policy.hasMaxSize).isEqualTo(true)
         assertThat(policy.maxSize).isEqualTo(10L)
     }
 
@@ -65,6 +66,7 @@ class MemoryPolicyBuilderTest {
         val policy = MemoryPolicy.builder()
                 .build()
 
-        assertThat(policy.maxSize).isEqualTo(1L)
+        assertThat(policy.hasMaxSize).isEqualTo(false)
+        assertThat(policy.maxSize).isEqualTo(MemoryPolicy.DEFAULT_POLICY)
     }
 }


### PR DESCRIPTION
Per the recently added docs for `MemoryPolicy.setMemorySize(maxSize: Long): MemoryPolicyBuilder`, when `setMemorySize` is not called, the cache size should be unlimited.

However currently the `maxSize` is automatically set to `1` with the default builder.
```kotlin
val policy = MemoryPolicy.builder().build() // maxSize is 1
```

This PR fixes this inconsistency with `Cache.Builder` by leaving the `maxSize` to `DEFAULT_POLICY` (-1) if not set explicitly.
