### PR TITLE
introduce piggyback only downstreams to multicaster and fix #59

### DIFF
--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/ChannelManager.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/ChannelManager.kt
@@ -277,7 +277,7 @@ internal class ChannelManager<T>(
          */
         private val channel: SendChannel<Message.Dispatch.Value<T>>,
         /**
-         * Tracking whether this channel a piggyback only channel that can be closed without ever
+         * Tracking whether this channel is a piggyback only channel that can be closed without ever
          * receiving a value or error.
          */
         val piggybackOnly: Boolean = false

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/Multicaster.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/Multicaster.kt
@@ -87,12 +87,12 @@ class Multicaster<T>(
      * The shared downstream flow. Collectors of this flow will share values dispatched by the
      * [source] Flow.
      */
-    val flow = flow<T> {
+    fun newFlow(piggybackOnly: Boolean = false) = flow<T> {
         val channel = Channel<ChannelManager.Message.Dispatch.Value<T>>(Channel.UNLIMITED)
         val subFlow = channel.consumeAsFlow()
             .onStart {
                 try {
-                    channelManager.addDownstream(channel)
+                    channelManager.addDownstream(channel, piggybackOnly)
                 } catch (closed: ClosedSendChannelException) {
                     // before we could start, channel manager was closed.
                     // close our downstream manually as it won't be closed by the ChannelManager

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/Multicaster.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/Multicaster.kt
@@ -87,13 +87,12 @@ class Multicaster<T>(
      * Gets a new downstream flow. Collectors of this flow will share values dispatched by a
      * single upstream [source] Flow.
      *
-     * @param piggybackOnly if true this downstream will cause a new upstream to start running
-     * (which only happens if no upstream is running alreay, e.g on if this is the first downstream
-     * added). Unlike a "regular" downstream, a [piggybackOnly] downstream can be closed without
-     * having any values emitted on it. [piggybackOnly] is only valid if [piggybackingDownstream] is
-     * enabled for this [Multicaster].
+     * @param piggybackOnly if true this downstream will not cause a new upstream to start running
+     * (which only happens if no upstream is running already, e.g if this is the first downstream
+     * added). [piggybackOnly] is only valid if [piggybackingDownstream] is enabled for this
+     * [Multicaster].
      */
-    fun newDownsteam(piggybackOnly: Boolean = false): Flow<T> {
+    fun newDownstream(piggybackOnly: Boolean = false): Flow<T> {
         check(!piggybackOnly || piggybackingDownstream) {
             "cannot create a piggyback only flow when piggybackDownstream is disabled"
         }

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/InfiniteMulticastTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/InfiniteMulticastTest.kt
@@ -69,19 +69,19 @@ class InfiniteMulticastTest {
             delay(100)
         })
         val c1 = async {
-            activeFlow.flow.onEach {
+            activeFlow.newFlow().onEach {
                 delay(100)
             }.take(6).toList()
         }
         val c2 = async {
-            activeFlow.flow.onEach {
+            activeFlow.newFlow().onEach {
                 delay(200)
             }.take(6).toList()
         }
         // ensure first flow finishes
         delay(10_000)
         // add another
-        val c3 = activeFlow.flow.take(3).toList()
+        val c3 = activeFlow.newFlow().take(3).toList()
         assertThat(c1.await())
             .isEqualTo(listOf("a0", "b0", "c0", "a1", "b1", "c1"))
         assertThat(c2.await())
@@ -104,19 +104,19 @@ class InfiniteMulticastTest {
             delay(100)
         })
         val c1 = async {
-            activeFlow.flow.onEach {
+            activeFlow.newFlow().onEach {
                 delay(100)
             }.take(6).toList()
         }
         val c2 = async {
-            activeFlow.flow.onEach {
+            activeFlow.newFlow().onEach {
                 delay(200)
             }.take(6).toList()
         }
         // ensure first flow finishes
         delay(10_000)
         // add another
-        val c3 = activeFlow.flow.take(1).toList()
+        val c3 = activeFlow.newFlow().take(1).toList()
         assertThat(c1.await())
             .isEqualTo(listOf("a0", "b0", "c0", "a1", "b1", "c1"))
         assertThat(c2.await())
@@ -139,19 +139,19 @@ class InfiniteMulticastTest {
             delay(100)
         })
         val c1 = async {
-            activeFlow.flow.onEach {
+            activeFlow.newFlow().onEach {
                 delay(100)
             }.take(4).toList()
         }
         val c2 = async {
-            activeFlow.flow.onEach {
+            activeFlow.newFlow().onEach {
                 delay(200)
             }.take(5).toList()
         }
         // ensure first flow finishes
         delay(10_000)
         // add another
-        val c3 = activeFlow.flow.take(3).toList()
+        val c3 = activeFlow.newFlow().take(3).toList()
         assertThat(c1.await())
             .isEqualTo(listOf("a0", "b0", "c0", "a1"))
         assertThat(c2.await())
@@ -175,19 +175,19 @@ class InfiniteMulticastTest {
             emit(it)
         })
         val c1 = async {
-            activeFlow.flow.onEach {
+            activeFlow.newFlow().onEach {
                 delay(100)
             }.take(4).toList()
         }
         val c2 = async {
-            activeFlow.flow.onEach {
+            activeFlow.newFlow().onEach {
                 delay(200)
             }.take(5).toList()
         }
         // ensure first flow finishes
         delay(10_000)
         // add another
-        val c3 = activeFlow.flow.take(1).toList()
+        val c3 = activeFlow.newFlow().take(1).toList()
         assertThat(c1.await())
             .isEqualTo(listOf("a0", "b0", "c0", "a1"))
         assertThat(c2.await())

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/InfiniteMulticastTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/InfiniteMulticastTest.kt
@@ -69,19 +69,19 @@ class InfiniteMulticastTest {
             delay(100)
         })
         val c1 = async {
-            activeFlow.newFlow().onEach {
+            activeFlow.newDownsteam().onEach {
                 delay(100)
             }.take(6).toList()
         }
         val c2 = async {
-            activeFlow.newFlow().onEach {
+            activeFlow.newDownsteam().onEach {
                 delay(200)
             }.take(6).toList()
         }
         // ensure first flow finishes
         delay(10_000)
         // add another
-        val c3 = activeFlow.newFlow().take(3).toList()
+        val c3 = activeFlow.newDownsteam().take(3).toList()
         assertThat(c1.await())
             .isEqualTo(listOf("a0", "b0", "c0", "a1", "b1", "c1"))
         assertThat(c2.await())
@@ -104,19 +104,19 @@ class InfiniteMulticastTest {
             delay(100)
         })
         val c1 = async {
-            activeFlow.newFlow().onEach {
+            activeFlow.newDownsteam().onEach {
                 delay(100)
             }.take(6).toList()
         }
         val c2 = async {
-            activeFlow.newFlow().onEach {
+            activeFlow.newDownsteam().onEach {
                 delay(200)
             }.take(6).toList()
         }
         // ensure first flow finishes
         delay(10_000)
         // add another
-        val c3 = activeFlow.newFlow().take(1).toList()
+        val c3 = activeFlow.newDownsteam().take(1).toList()
         assertThat(c1.await())
             .isEqualTo(listOf("a0", "b0", "c0", "a1", "b1", "c1"))
         assertThat(c2.await())
@@ -139,19 +139,19 @@ class InfiniteMulticastTest {
             delay(100)
         })
         val c1 = async {
-            activeFlow.newFlow().onEach {
+            activeFlow.newDownsteam().onEach {
                 delay(100)
             }.take(4).toList()
         }
         val c2 = async {
-            activeFlow.newFlow().onEach {
+            activeFlow.newDownsteam().onEach {
                 delay(200)
             }.take(5).toList()
         }
         // ensure first flow finishes
         delay(10_000)
         // add another
-        val c3 = activeFlow.newFlow().take(3).toList()
+        val c3 = activeFlow.newDownsteam().take(3).toList()
         assertThat(c1.await())
             .isEqualTo(listOf("a0", "b0", "c0", "a1"))
         assertThat(c2.await())
@@ -175,19 +175,19 @@ class InfiniteMulticastTest {
             emit(it)
         })
         val c1 = async {
-            activeFlow.newFlow().onEach {
+            activeFlow.newDownsteam().onEach {
                 delay(100)
             }.take(4).toList()
         }
         val c2 = async {
-            activeFlow.newFlow().onEach {
+            activeFlow.newDownsteam().onEach {
                 delay(200)
             }.take(5).toList()
         }
         // ensure first flow finishes
         delay(10_000)
         // add another
-        val c3 = activeFlow.newFlow().take(1).toList()
+        val c3 = activeFlow.newDownsteam().take(1).toList()
         assertThat(c1.await())
             .isEqualTo(listOf("a0", "b0", "c0", "a1"))
         assertThat(c2.await())

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/InfiniteMulticastTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/InfiniteMulticastTest.kt
@@ -69,19 +69,19 @@ class InfiniteMulticastTest {
             delay(100)
         })
         val c1 = async {
-            activeFlow.newDownsteam().onEach {
+            activeFlow.newDownstream().onEach {
                 delay(100)
             }.take(6).toList()
         }
         val c2 = async {
-            activeFlow.newDownsteam().onEach {
+            activeFlow.newDownstream().onEach {
                 delay(200)
             }.take(6).toList()
         }
         // ensure first flow finishes
         delay(10_000)
         // add another
-        val c3 = activeFlow.newDownsteam().take(3).toList()
+        val c3 = activeFlow.newDownstream().take(3).toList()
         assertThat(c1.await())
             .isEqualTo(listOf("a0", "b0", "c0", "a1", "b1", "c1"))
         assertThat(c2.await())
@@ -104,19 +104,19 @@ class InfiniteMulticastTest {
             delay(100)
         })
         val c1 = async {
-            activeFlow.newDownsteam().onEach {
+            activeFlow.newDownstream().onEach {
                 delay(100)
             }.take(6).toList()
         }
         val c2 = async {
-            activeFlow.newDownsteam().onEach {
+            activeFlow.newDownstream().onEach {
                 delay(200)
             }.take(6).toList()
         }
         // ensure first flow finishes
         delay(10_000)
         // add another
-        val c3 = activeFlow.newDownsteam().take(1).toList()
+        val c3 = activeFlow.newDownstream().take(1).toList()
         assertThat(c1.await())
             .isEqualTo(listOf("a0", "b0", "c0", "a1", "b1", "c1"))
         assertThat(c2.await())
@@ -139,19 +139,19 @@ class InfiniteMulticastTest {
             delay(100)
         })
         val c1 = async {
-            activeFlow.newDownsteam().onEach {
+            activeFlow.newDownstream().onEach {
                 delay(100)
             }.take(4).toList()
         }
         val c2 = async {
-            activeFlow.newDownsteam().onEach {
+            activeFlow.newDownstream().onEach {
                 delay(200)
             }.take(5).toList()
         }
         // ensure first flow finishes
         delay(10_000)
         // add another
-        val c3 = activeFlow.newDownsteam().take(3).toList()
+        val c3 = activeFlow.newDownstream().take(3).toList()
         assertThat(c1.await())
             .isEqualTo(listOf("a0", "b0", "c0", "a1"))
         assertThat(c2.await())
@@ -175,19 +175,19 @@ class InfiniteMulticastTest {
             emit(it)
         })
         val c1 = async {
-            activeFlow.newDownsteam().onEach {
+            activeFlow.newDownstream().onEach {
                 delay(100)
             }.take(4).toList()
         }
         val c2 = async {
-            activeFlow.newDownsteam().onEach {
+            activeFlow.newDownstream().onEach {
                 delay(200)
             }.take(5).toList()
         }
         // ensure first flow finishes
         delay(10_000)
         // add another
-        val c3 = activeFlow.newDownsteam().take(1).toList()
+        val c3 = activeFlow.newDownstream().take(1).toList()
         assertThat(c1.await())
             .isEqualTo(listOf("a0", "b0", "c0", "a1"))
         assertThat(c2.await())

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/MulticastTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/MulticastTest.kt
@@ -76,9 +76,9 @@ class MulticastTest {
                 }
             }
         )
-        assertThat(activeFlow.newDownsteam().toList())
+        assertThat(activeFlow.newDownstream().toList())
             .isEqualTo(listOf("a", "b", "c"))
-        assertThat(activeFlow.newDownsteam().toList())
+        assertThat(activeFlow.newDownstream().toList())
             .isEqualTo(listOf("d", "e", "f"))
     }
 
@@ -91,12 +91,12 @@ class MulticastTest {
             }
         )
         val c1 = async {
-            activeFlow.newDownsteam().onEach {
+            activeFlow.newDownstream().onEach {
                 delay(100)
             }.toList()
         }
         val c2 = async {
-            activeFlow.newDownsteam().onEach {
+            activeFlow.newDownstream().onEach {
                 delay(200)
             }.toList()
         }
@@ -114,10 +114,10 @@ class MulticastTest {
             }
         )
         val c1 = async {
-            activeFlow.newDownsteam().toList()
+            activeFlow.newDownstream().toList()
         }
         val c2 = async {
-            activeFlow.newDownsteam().toList()
+            activeFlow.newDownstream().toList()
         }
         assertThat(c1.await()).isEqualTo(listOf("a", "b", "c"))
         assertThat(c2.await()).isEqualTo(listOf("a", "b", "c"))
@@ -131,10 +131,10 @@ class MulticastTest {
             }
         )
         val c1 = async {
-            activeFlow.newDownsteam().toList()
+            activeFlow.newDownstream().toList()
         }
         val c2 = async {
-            activeFlow.newDownsteam().also {
+            activeFlow.newDownstream().also {
                 delay(110)
             }.toList()
         }
@@ -158,16 +158,16 @@ class MulticastTest {
             }
         )
         val c1 = async {
-            activeFlow.newDownsteam().onEach {
+            activeFlow.newDownstream().onEach {
             }.toList()
         }
         val c2 = async {
-            activeFlow.newDownsteam().also {
+            activeFlow.newDownstream().also {
                 delay(3)
             }.toList()
         }
         val c3 = async {
-            activeFlow.newDownsteam().also {
+            activeFlow.newDownstream().also {
                 delay(20)
             }.toList()
         }
@@ -191,7 +191,7 @@ class MulticastTest {
         )
         val receivedValue = CompletableDeferred<String>()
         val receivedError = CompletableDeferred<Throwable>()
-        activeFlow.newDownsteam()
+        activeFlow.newDownstream()
             .onEach {
                 check(receivedValue.isActive) {
                     "already received value"
@@ -224,13 +224,13 @@ class MulticastTest {
             }
         )
         launch {
-            activeFlow.newDownsteam().catch {}.toList()
+            activeFlow.newDownstream().catch {}.toList()
         }
         // wait until the above collector registers and receives first value
         dispatchedFirstValue.await()
         val receivedValue = CompletableDeferred<String>()
         val receivedError = CompletableDeferred<Throwable>()
-        activeFlow.newDownsteam()
+        activeFlow.newDownstream()
             .onStart {
                 registeredSecondCollector.complete(Unit)
             }
@@ -267,12 +267,12 @@ class MulticastTest {
             }
         )
         val firstCollector = async {
-            activeFlow.newDownsteam().onEach { delay(5) }.take(2).toList()
+            activeFlow.newDownstream().onEach { delay(5) }.take(2).toList()
         }
         delay(11) // miss first two values
         val secondCollector = async {
             // this will come in a new channel
-            activeFlow.newDownsteam().take(2).toList()
+            activeFlow.newDownstream().take(2).toList()
         }
         assertThat(firstCollector.await()).isEqualTo(listOf("a_1", "b_1"))
         assertThat(secondCollector.await()).isEqualTo(listOf("a_2", "b_2"))
@@ -302,19 +302,19 @@ class MulticastTest {
             onEach = {}
         )
         val c1 = async {
-            activeFlow.newDownsteam().toList()
+            activeFlow.newDownstream().toList()
         }
         delay(4) // c2 misses first value
         val c2 = async {
-            activeFlow.newDownsteam().toList()
+            activeFlow.newDownstream().toList()
         }
         delay(50) // c3 misses first 4 values
         val c3 = async {
-            activeFlow.newDownsteam().toList()
+            activeFlow.newDownstream().toList()
         }
         delay(100) // c4 misses all values
         val c4 = async {
-            activeFlow.newDownsteam().toList()
+            activeFlow.newDownstream().toList()
         }
         assertThat(c1.await()).isEqualTo(listOf("a", "b", "c", "d", "e"))
         assertThat(c2.await()).isEqualTo(listOf("a", "b", "c", "d", "e"))
@@ -331,8 +331,8 @@ class MulticastTest {
             source = flowOf(1, 2, 3),
             onEach = {}
         )
-        assertThat(activeFlow.newDownsteam().toList()).isEqualTo(listOf(1, 2, 3))
-        assertThat(activeFlow.newDownsteam().toList()).isEqualTo(listOf(1, 2, 3))
+        assertThat(activeFlow.newDownstream().toList()).isEqualTo(listOf(1, 2, 3))
+        assertThat(activeFlow.newDownstream().toList()).isEqualTo(listOf(1, 2, 3))
     }
 
     @Test
@@ -344,14 +344,14 @@ class MulticastTest {
         )
         val unlockC1 = CompletableDeferred<Unit>()
         val c1 = async {
-            activeFlow.newDownsteam().collect {
+            activeFlow.newDownstream().collect {
                 unlockC1.await()
                 // never ack!
                 throw RuntimeException("done 1")
             }
         }
         val c2 = async {
-            activeFlow.newDownsteam().toList()
+            activeFlow.newDownstream().toList()
         }
         testScope.runCurrent()
         assertThat(c2.isActive).isFalse()
@@ -368,14 +368,14 @@ class MulticastTest {
         )
         val unlockC1 = CompletableDeferred<Unit>()
         val c1 = async {
-            activeFlow.newDownsteam().collect {
+            activeFlow.newDownstream().collect {
                 unlockC1.await()
                 // never ack!
                 throw RuntimeException("done 1")
             }
         }
         val c2 = async {
-            activeFlow.newDownsteam().toList()
+            activeFlow.newDownstream().toList()
         }
         testScope.runCurrent()
         assertThat(c2.isActive).isFalse()
@@ -392,13 +392,13 @@ class MulticastTest {
         )
         val unlockC1 = CompletableDeferred<Unit>()
         val c1 = async {
-            activeFlow.newDownsteam().collect {
+            activeFlow.newDownstream().collect {
                 unlockC1.await()
                 throw RuntimeException("done 1")
             }
         }
         val c2 = async {
-            activeFlow.newDownsteam().toList()
+            activeFlow.newDownstream().toList()
         }
         testScope.runCurrent()
         assertThat(c2.isActive).isFalse()
@@ -416,7 +416,7 @@ class MulticastTest {
             suspendCancellableCoroutine<Unit> {}
         })
         val collection = async {
-            multicaster.newDownsteam().toList()
+            multicaster.newDownstream().toList()
         }
         runCurrent()
         assertThat(collection.isActive).isTrue()
@@ -439,7 +439,7 @@ class MulticastTest {
         // now add a subscriber, should just close immediately
         runCurrent()
         val collection = async {
-            multicaster.newDownsteam().toList()
+            multicaster.newDownstream().toList()
         }
         runCurrent()
         assertThat(collection.isActive).isFalse()
@@ -459,7 +459,7 @@ class MulticastTest {
             bufferSize = 10
         )
         async {
-            multicaster.newDownsteam().toList()
+            multicaster.newDownstream().toList()
         }
         runCurrent()
         multicaster.close()
@@ -468,7 +468,7 @@ class MulticastTest {
         // note that even there is a buffer, closing multicast releases all resources so buffer
         // will be gone as well.
         val collection2 = async {
-            multicaster.newDownsteam().toList()
+            multicaster.newDownstream().toList()
         }
         runCurrent()
         assertThat(collection2.isActive).isFalse()
@@ -485,13 +485,13 @@ class MulticastTest {
             }
             val multicaster =
                 createMulticaster(flow = source, piggybackDownstream = true)
-            val piggybackDownstream = multicaster.newDownsteam(piggybackOnly = true)
+            val piggybackDownstream = multicaster.newDownstream(piggybackOnly = true)
             val piggybackValue = testScope.async { piggybackDownstream.first() }
             testScope.advanceUntilIdle()
             assertThat(createCount).isEqualTo(0)
             assertThat(piggybackValue.isCompleted).isEqualTo(false)
 
-            val downstream = multicaster.newDownsteam(piggybackOnly = false)
+            val downstream = multicaster.newDownstream(piggybackOnly = false)
             val value = testScope.async { downstream.first() }
             testScope.advanceUntilIdle()
             assertThat(createCount).isEqualTo(1)
@@ -505,7 +505,7 @@ class MulticastTest {
     fun `GIVEN no piggybackDownstream WHEN adding a piggybackOnly downstream THAN throws IllegalStateException`() =
         testScope.runBlockingTest {
             val multicaster = createMulticaster(flowOf("a"), piggybackDownstream = false)
-            multicaster.newDownsteam(piggybackOnly = true)
+            multicaster.newDownstream(piggybackOnly = true)
         }
 
     private fun versionedMulticaster(

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/MulticastTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/MulticastTest.kt
@@ -69,9 +69,9 @@ class MulticastTest {
                 }
             }
         )
-        assertThat(activeFlow.flow.toList())
+        assertThat(activeFlow.newFlow().toList())
             .isEqualTo(listOf("a", "b", "c"))
-        assertThat(activeFlow.flow.toList())
+        assertThat(activeFlow.newFlow().toList())
             .isEqualTo(listOf("d", "e", "f"))
     }
 
@@ -84,12 +84,12 @@ class MulticastTest {
             }
         )
         val c1 = async {
-            activeFlow.flow.onEach {
+            activeFlow.newFlow().onEach {
                 delay(100)
             }.toList()
         }
         val c2 = async {
-            activeFlow.flow.onEach {
+            activeFlow.newFlow().onEach {
                 delay(200)
             }.toList()
         }
@@ -107,10 +107,10 @@ class MulticastTest {
             }
         )
         val c1 = async {
-            activeFlow.flow.toList()
+            activeFlow.newFlow().toList()
         }
         val c2 = async {
-            activeFlow.flow.toList()
+            activeFlow.newFlow().toList()
         }
         assertThat(c1.await()).isEqualTo(listOf("a", "b", "c"))
         assertThat(c2.await()).isEqualTo(listOf("a", "b", "c"))
@@ -124,10 +124,10 @@ class MulticastTest {
             }
         )
         val c1 = async {
-            activeFlow.flow.toList()
+            activeFlow.newFlow().toList()
         }
         val c2 = async {
-            activeFlow.flow.also {
+            activeFlow.newFlow().also {
                 delay(110)
             }.toList()
         }
@@ -151,16 +151,16 @@ class MulticastTest {
             }
         )
         val c1 = async {
-            activeFlow.flow.onEach {
+            activeFlow.newFlow().onEach {
             }.toList()
         }
         val c2 = async {
-            activeFlow.flow.also {
+            activeFlow.newFlow().also {
                 delay(3)
             }.toList()
         }
         val c3 = async {
-            activeFlow.flow.also {
+            activeFlow.newFlow().also {
                 delay(20)
             }.toList()
         }
@@ -184,7 +184,7 @@ class MulticastTest {
         )
         val receivedValue = CompletableDeferred<String>()
         val receivedError = CompletableDeferred<Throwable>()
-        activeFlow.flow
+        activeFlow.newFlow()
             .onEach {
                 check(receivedValue.isActive) {
                     "already received value"
@@ -217,13 +217,13 @@ class MulticastTest {
             }
         )
         launch {
-            activeFlow.flow.catch {}.toList()
+            activeFlow.newFlow().catch {}.toList()
         }
         // wait until the above collector registers and receives first value
         dispatchedFirstValue.await()
         val receivedValue = CompletableDeferred<String>()
         val receivedError = CompletableDeferred<Throwable>()
-        activeFlow.flow
+        activeFlow.newFlow()
             .onStart {
                 registeredSecondCollector.complete(Unit)
             }
@@ -260,12 +260,12 @@ class MulticastTest {
             }
         )
         val firstCollector = async {
-            activeFlow.flow.onEach { delay(5) }.take(2).toList()
+            activeFlow.newFlow().onEach { delay(5) }.take(2).toList()
         }
         delay(11) // miss first two values
         val secondCollector = async {
             // this will come in a new channel
-            activeFlow.flow.take(2).toList()
+            activeFlow.newFlow().take(2).toList()
         }
         assertThat(firstCollector.await()).isEqualTo(listOf("a_1", "b_1"))
         assertThat(secondCollector.await()).isEqualTo(listOf("a_2", "b_2"))
@@ -295,19 +295,19 @@ class MulticastTest {
             onEach = {}
         )
         val c1 = async {
-            activeFlow.flow.toList()
+            activeFlow.newFlow().toList()
         }
         delay(4) // c2 misses first value
         val c2 = async {
-            activeFlow.flow.toList()
+            activeFlow.newFlow().toList()
         }
         delay(50) // c3 misses first 4 values
         val c3 = async {
-            activeFlow.flow.toList()
+            activeFlow.newFlow().toList()
         }
         delay(100) // c4 misses all values
         val c4 = async {
-            activeFlow.flow.toList()
+            activeFlow.newFlow().toList()
         }
         assertThat(c1.await()).isEqualTo(listOf("a", "b", "c", "d", "e"))
         assertThat(c2.await()).isEqualTo(listOf("a", "b", "c", "d", "e"))
@@ -324,8 +324,8 @@ class MulticastTest {
             source = flowOf(1, 2, 3),
             onEach = {}
         )
-        assertThat(activeFlow.flow.toList()).isEqualTo(listOf(1, 2, 3))
-        assertThat(activeFlow.flow.toList()).isEqualTo(listOf(1, 2, 3))
+        assertThat(activeFlow.newFlow().toList()).isEqualTo(listOf(1, 2, 3))
+        assertThat(activeFlow.newFlow().toList()).isEqualTo(listOf(1, 2, 3))
     }
 
     @Test
@@ -337,14 +337,14 @@ class MulticastTest {
         )
         val unlockC1 = CompletableDeferred<Unit>()
         val c1 = async {
-            activeFlow.flow.collect {
+            activeFlow.newFlow().collect {
                 unlockC1.await()
                 // never ack!
                 throw RuntimeException("done 1")
             }
         }
         val c2 = async {
-            activeFlow.flow.toList()
+            activeFlow.newFlow().toList()
         }
         testScope.runCurrent()
         assertThat(c2.isActive).isFalse()
@@ -361,14 +361,14 @@ class MulticastTest {
         )
         val unlockC1 = CompletableDeferred<Unit>()
         val c1 = async {
-            activeFlow.flow.collect {
+            activeFlow.newFlow().collect {
                 unlockC1.await()
                 // never ack!
                 throw RuntimeException("done 1")
             }
         }
         val c2 = async {
-            activeFlow.flow.toList()
+            activeFlow.newFlow().toList()
         }
         testScope.runCurrent()
         assertThat(c2.isActive).isFalse()
@@ -385,13 +385,13 @@ class MulticastTest {
         )
         val unlockC1 = CompletableDeferred<Unit>()
         val c1 = async {
-            activeFlow.flow.collect {
+            activeFlow.newFlow().collect {
                 unlockC1.await()
                 throw RuntimeException("done 1")
             }
         }
         val c2 = async {
-            activeFlow.flow.toList()
+            activeFlow.newFlow().toList()
         }
         testScope.runCurrent()
         assertThat(c2.isActive).isFalse()
@@ -409,7 +409,7 @@ class MulticastTest {
             suspendCancellableCoroutine<Unit> {}
         })
         val collection = async {
-            multicaster.flow.toList()
+            multicaster.newFlow().toList()
         }
         runCurrent()
         assertThat(collection.isActive).isTrue()
@@ -432,7 +432,7 @@ class MulticastTest {
         // now add a subscriber, should just close immediately
         runCurrent()
         val collection = async {
-            multicaster.flow.toList()
+            multicaster.newFlow().toList()
         }
         runCurrent()
         assertThat(collection.isActive).isFalse()
@@ -452,7 +452,7 @@ class MulticastTest {
             bufferSize = 10
         )
         async {
-            multicaster.flow.toList()
+            multicaster.newFlow().toList()
         }
         runCurrent()
         multicaster.close()
@@ -461,7 +461,7 @@ class MulticastTest {
         // note that even there is a buffer, closing multicast releases all resources so buffer
         // will be gone as well.
         val collection2 = async {
-            multicaster.flow.toList()
+            multicaster.newFlow().toList()
         }
         runCurrent()
         assertThat(collection2.isActive).isFalse()

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/MulticastTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/MulticastTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -48,12 +49,18 @@ import org.junit.runners.JUnit4
 class MulticastTest {
     private val testScope = TestCoroutineScope()
 
-    private fun <T> createMulticaster(flow: Flow<T>, bufferSize: Int = 0): Multicaster<T> {
+    private fun <T> createMulticaster(
+        flow: Flow<T>,
+        bufferSize: Int = 0,
+        piggybackDownstream: Boolean = false
+    ): Multicaster<T> {
         return Multicaster(
             scope = testScope,
             bufferSize = bufferSize,
             source = flow,
-            onEach = {})
+            onEach = {},
+            piggybackingDownstream = piggybackDownstream
+        )
     }
 
     @Test
@@ -69,9 +76,9 @@ class MulticastTest {
                 }
             }
         )
-        assertThat(activeFlow.newFlow().toList())
+        assertThat(activeFlow.newDownsteam().toList())
             .isEqualTo(listOf("a", "b", "c"))
-        assertThat(activeFlow.newFlow().toList())
+        assertThat(activeFlow.newDownsteam().toList())
             .isEqualTo(listOf("d", "e", "f"))
     }
 
@@ -84,12 +91,12 @@ class MulticastTest {
             }
         )
         val c1 = async {
-            activeFlow.newFlow().onEach {
+            activeFlow.newDownsteam().onEach {
                 delay(100)
             }.toList()
         }
         val c2 = async {
-            activeFlow.newFlow().onEach {
+            activeFlow.newDownsteam().onEach {
                 delay(200)
             }.toList()
         }
@@ -107,10 +114,10 @@ class MulticastTest {
             }
         )
         val c1 = async {
-            activeFlow.newFlow().toList()
+            activeFlow.newDownsteam().toList()
         }
         val c2 = async {
-            activeFlow.newFlow().toList()
+            activeFlow.newDownsteam().toList()
         }
         assertThat(c1.await()).isEqualTo(listOf("a", "b", "c"))
         assertThat(c2.await()).isEqualTo(listOf("a", "b", "c"))
@@ -124,10 +131,10 @@ class MulticastTest {
             }
         )
         val c1 = async {
-            activeFlow.newFlow().toList()
+            activeFlow.newDownsteam().toList()
         }
         val c2 = async {
-            activeFlow.newFlow().also {
+            activeFlow.newDownsteam().also {
                 delay(110)
             }.toList()
         }
@@ -151,16 +158,16 @@ class MulticastTest {
             }
         )
         val c1 = async {
-            activeFlow.newFlow().onEach {
+            activeFlow.newDownsteam().onEach {
             }.toList()
         }
         val c2 = async {
-            activeFlow.newFlow().also {
+            activeFlow.newDownsteam().also {
                 delay(3)
             }.toList()
         }
         val c3 = async {
-            activeFlow.newFlow().also {
+            activeFlow.newDownsteam().also {
                 delay(20)
             }.toList()
         }
@@ -184,7 +191,7 @@ class MulticastTest {
         )
         val receivedValue = CompletableDeferred<String>()
         val receivedError = CompletableDeferred<Throwable>()
-        activeFlow.newFlow()
+        activeFlow.newDownsteam()
             .onEach {
                 check(receivedValue.isActive) {
                     "already received value"
@@ -217,13 +224,13 @@ class MulticastTest {
             }
         )
         launch {
-            activeFlow.newFlow().catch {}.toList()
+            activeFlow.newDownsteam().catch {}.toList()
         }
         // wait until the above collector registers and receives first value
         dispatchedFirstValue.await()
         val receivedValue = CompletableDeferred<String>()
         val receivedError = CompletableDeferred<Throwable>()
-        activeFlow.newFlow()
+        activeFlow.newDownsteam()
             .onStart {
                 registeredSecondCollector.complete(Unit)
             }
@@ -260,12 +267,12 @@ class MulticastTest {
             }
         )
         val firstCollector = async {
-            activeFlow.newFlow().onEach { delay(5) }.take(2).toList()
+            activeFlow.newDownsteam().onEach { delay(5) }.take(2).toList()
         }
         delay(11) // miss first two values
         val secondCollector = async {
             // this will come in a new channel
-            activeFlow.newFlow().take(2).toList()
+            activeFlow.newDownsteam().take(2).toList()
         }
         assertThat(firstCollector.await()).isEqualTo(listOf("a_1", "b_1"))
         assertThat(secondCollector.await()).isEqualTo(listOf("a_2", "b_2"))
@@ -295,19 +302,19 @@ class MulticastTest {
             onEach = {}
         )
         val c1 = async {
-            activeFlow.newFlow().toList()
+            activeFlow.newDownsteam().toList()
         }
         delay(4) // c2 misses first value
         val c2 = async {
-            activeFlow.newFlow().toList()
+            activeFlow.newDownsteam().toList()
         }
         delay(50) // c3 misses first 4 values
         val c3 = async {
-            activeFlow.newFlow().toList()
+            activeFlow.newDownsteam().toList()
         }
         delay(100) // c4 misses all values
         val c4 = async {
-            activeFlow.newFlow().toList()
+            activeFlow.newDownsteam().toList()
         }
         assertThat(c1.await()).isEqualTo(listOf("a", "b", "c", "d", "e"))
         assertThat(c2.await()).isEqualTo(listOf("a", "b", "c", "d", "e"))
@@ -324,8 +331,8 @@ class MulticastTest {
             source = flowOf(1, 2, 3),
             onEach = {}
         )
-        assertThat(activeFlow.newFlow().toList()).isEqualTo(listOf(1, 2, 3))
-        assertThat(activeFlow.newFlow().toList()).isEqualTo(listOf(1, 2, 3))
+        assertThat(activeFlow.newDownsteam().toList()).isEqualTo(listOf(1, 2, 3))
+        assertThat(activeFlow.newDownsteam().toList()).isEqualTo(listOf(1, 2, 3))
     }
 
     @Test
@@ -337,14 +344,14 @@ class MulticastTest {
         )
         val unlockC1 = CompletableDeferred<Unit>()
         val c1 = async {
-            activeFlow.newFlow().collect {
+            activeFlow.newDownsteam().collect {
                 unlockC1.await()
                 // never ack!
                 throw RuntimeException("done 1")
             }
         }
         val c2 = async {
-            activeFlow.newFlow().toList()
+            activeFlow.newDownsteam().toList()
         }
         testScope.runCurrent()
         assertThat(c2.isActive).isFalse()
@@ -361,14 +368,14 @@ class MulticastTest {
         )
         val unlockC1 = CompletableDeferred<Unit>()
         val c1 = async {
-            activeFlow.newFlow().collect {
+            activeFlow.newDownsteam().collect {
                 unlockC1.await()
                 // never ack!
                 throw RuntimeException("done 1")
             }
         }
         val c2 = async {
-            activeFlow.newFlow().toList()
+            activeFlow.newDownsteam().toList()
         }
         testScope.runCurrent()
         assertThat(c2.isActive).isFalse()
@@ -385,13 +392,13 @@ class MulticastTest {
         )
         val unlockC1 = CompletableDeferred<Unit>()
         val c1 = async {
-            activeFlow.newFlow().collect {
+            activeFlow.newDownsteam().collect {
                 unlockC1.await()
                 throw RuntimeException("done 1")
             }
         }
         val c2 = async {
-            activeFlow.newFlow().toList()
+            activeFlow.newDownsteam().toList()
         }
         testScope.runCurrent()
         assertThat(c2.isActive).isFalse()
@@ -409,7 +416,7 @@ class MulticastTest {
             suspendCancellableCoroutine<Unit> {}
         })
         val collection = async {
-            multicaster.newFlow().toList()
+            multicaster.newDownsteam().toList()
         }
         runCurrent()
         assertThat(collection.isActive).isTrue()
@@ -432,7 +439,7 @@ class MulticastTest {
         // now add a subscriber, should just close immediately
         runCurrent()
         val collection = async {
-            multicaster.newFlow().toList()
+            multicaster.newDownsteam().toList()
         }
         runCurrent()
         assertThat(collection.isActive).isFalse()
@@ -452,7 +459,7 @@ class MulticastTest {
             bufferSize = 10
         )
         async {
-            multicaster.newFlow().toList()
+            multicaster.newDownsteam().toList()
         }
         runCurrent()
         multicaster.close()
@@ -461,12 +468,45 @@ class MulticastTest {
         // note that even there is a buffer, closing multicast releases all resources so buffer
         // will be gone as well.
         val collection2 = async {
-            multicaster.newFlow().toList()
+            multicaster.newDownsteam().toList()
         }
         runCurrent()
         assertThat(collection2.isActive).isFalse()
         assertThat(collection2.await()).isEmpty()
     }
+
+    @Test
+    fun `GIVEN piggybackDownstream AND piggybackOnly downstream followed by regular downstream WHEN add piggback downstream AND add downstream THAN upstream does not start until 2nd downstream is added AND both get value`() =
+        testScope.runBlockingTest {
+            var createCount = 0
+            val source = flow {
+                createCount++
+                emit("value")
+            }
+            val multicaster =
+                createMulticaster(flow = source, piggybackDownstream = true)
+            val piggybackDownstream = multicaster.newDownsteam(piggybackOnly = true)
+            val piggybackValue = testScope.async { piggybackDownstream.first() }
+            testScope.advanceUntilIdle()
+            assertThat(createCount).isEqualTo(0)
+            assertThat(piggybackValue.isCompleted).isEqualTo(false)
+
+            val downstream = multicaster.newDownsteam(piggybackOnly = false)
+            val value = testScope.async { downstream.first() }
+            testScope.advanceUntilIdle()
+            assertThat(createCount).isEqualTo(1)
+            assertThat(piggybackValue.isCompleted).isEqualTo(true)
+            assertThat(piggybackValue.getCompleted()).isEqualTo("value")
+            assertThat(value.isCompleted).isEqualTo(true)
+            assertThat(value.getCompleted()).isEqualTo("value")
+        }
+
+    @Test(expected = IllegalStateException::class)
+    fun `GIVEN no piggybackDownstream WHEN adding a piggybackOnly downstream THAN throws IllegalStateException`() =
+        testScope.runBlockingTest {
+            val multicaster = createMulticaster(flowOf("a"), piggybackDownstream = false)
+            multicaster.newDownsteam(piggybackOnly = true)
+        }
 
     private fun versionedMulticaster(
         bufferSize: Int = 0,

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/MulticastTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/MulticastTest.kt
@@ -476,7 +476,7 @@ class MulticastTest {
     }
 
     @Test
-    fun `GIVEN piggybackDownstream AND piggybackOnly downstream followed by regular downstream WHEN add piggback downstream AND add downstream THAN upstream does not start until 2nd downstream is added AND both get value`() =
+    fun `GIVEN piggybackDownstream AND piggybackOnly downstream followed by regular downstream WHEN add piggback downstream AND add downstream THEN upstream does not start until 2nd downstream is added AND both get value`() =
         testScope.runBlockingTest {
             var createCount = 0
             val source = flow {
@@ -502,7 +502,7 @@ class MulticastTest {
         }
 
     @Test(expected = IllegalStateException::class)
-    fun `GIVEN no piggybackDownstream WHEN adding a piggybackOnly downstream THAN throws IllegalStateException`() =
+    fun `GIVEN no piggybackDownstream WHEN adding a piggybackOnly downstream THEN throws IllegalStateException`() =
         testScope.runBlockingTest {
             val multicaster = createMulticaster(flowOf("a"), piggybackDownstream = false)
             multicaster.newDownstream(piggybackOnly = true)

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/FetcherController.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/FetcherController.kt
@@ -88,7 +88,7 @@ internal class FetcherController<Key, Input, Output>(
         return flow {
             val fetcher = fetchers.acquire(key)
             try {
-                emitAll(fetcher.newDownsteam(piggybackOnly))
+                emitAll(fetcher.newDownstream(piggybackOnly))
             } finally {
                 fetchers.release(key, fetcher)
             }

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/FetcherController.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/FetcherController.kt
@@ -88,7 +88,7 @@ internal class FetcherController<Key, Input, Output>(
         return flow {
             val fetcher = fetchers.acquire(key)
             try {
-                emitAll(fetcher.newFlow(piggybackOnly))
+                emitAll(fetcher.newDownsteam(piggybackOnly))
             } finally {
                 fetchers.release(key, fetcher)
             }

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/FetcherController.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/FetcherController.kt
@@ -84,11 +84,11 @@ internal class FetcherController<Key, Input, Output>(
         }
     )
 
-    fun getFetcher(key: Key): Flow<StoreResponse<Input>> {
+    fun getFetcher(key: Key, piggybackOnly: Boolean = false): Flow<StoreResponse<Input>> {
         return flow {
             val fetcher = fetchers.acquire(key)
             try {
-                emitAll(fetcher.flow)
+                emitAll(fetcher.newFlow(piggybackOnly))
             } finally {
                 fetchers.release(key, fetcher)
             }

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
@@ -36,7 +36,6 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
@@ -90,7 +90,6 @@ class FlowStoreTest {
             )
         assertThat(
             pipeline.stream(StoreRequest.cached(3, refresh = false))
-                .take(1)
         )
             .emitsExactly(
                 Data(

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
@@ -24,10 +24,14 @@ import com.dropbox.android.external.store4.StoreRequest
 import com.dropbox.android.external.store4.StoreResponse
 import com.dropbox.android.external.store4.StoreResponse.Data
 import com.dropbox.android.external.store4.StoreResponse.Loading
+import com.dropbox.android.external.store4.fresh
+import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
@@ -442,6 +446,104 @@ class FlowStoreTest {
                     origin = Fetcher
                 )
             )
+    }
+    data class StringWrapper(val wrapped: String)
+
+    @Test
+    fun avoidRefresh_withoutSourceOfTruth() = testScope.runBlockingTest {
+        val fetcher = FakeFetcher(
+            3 to "three-1",
+            3 to "three-2"
+        )
+        val pipeline = build<Int, String, String>(
+            nonFlowingFetcher = fetcher::fetch,
+            enableCache = true
+        )
+        val firstFetch = pipeline.fresh(3)
+        assertThat(firstFetch).isEqualTo("three-1")
+        val secondCollect = mutableListOf<StoreResponse<String>>()
+        val collection = launch {
+            pipeline.stream(StoreRequest.cached(3, refresh = false)).collect {
+                secondCollect.add(it)
+            }
+        }
+        testScope.runCurrent()
+        assertThat(secondCollect).containsExactly(
+            Data(
+                value = "three-1",
+                origin = Cache
+            )
+        )
+        // trigger another fetch from network
+        val secondFetch = pipeline.fresh(3)
+        assertThat(secondFetch).isEqualTo("three-2")
+        testScope.runCurrent()
+        // make sure cached also received it
+        assertThat(secondCollect).containsExactly(
+            Data(
+                value = "three-1",
+                origin = Cache
+            ),
+            Data(
+                value = "three-2",
+                origin = Fetcher
+            )
+        )
+        collection.cancelAndJoin()
+    }
+
+    @Test
+    fun avoidRefresh_withSourceOfTruth() = testScope.runBlockingTest {
+        val fetcher = FakeFetcher(
+            3 to "three-1",
+            3 to "three-2"
+        )
+        val persister = InMemoryPersister<Int, String>()
+        val pipeline = build(
+            nonFlowingFetcher = fetcher::fetch,
+            persisterReader = { key -> persister.read(key)?.let {StringWrapper(it)} },
+            persisterWriter = persister::write,
+            enableCache = true
+        )
+        val firstFetch = pipeline.fresh(3)
+        assertThat(firstFetch).isEqualTo(StringWrapper("three-1"))
+        val secondCollect = mutableListOf<StoreResponse<StringWrapper>>()
+        val collection = launch {
+            pipeline.stream(StoreRequest.cached(3, refresh = false)).collect {
+                secondCollect.add(it)
+            }
+        }
+        testScope.runCurrent()
+        assertThat(secondCollect).containsExactly(
+            Data(
+                value = StringWrapper("three-1"),
+                origin = Cache
+            ),
+            Data(
+                value = StringWrapper("three-1"),
+                origin = Persister
+            )
+        )
+        // trigger another fetch from network
+        val secondFetch = pipeline.fresh(3)
+        assertThat(secondFetch).isEqualTo(StringWrapper("three-2"))
+        testScope.runCurrent()
+        // make sure cached also received it
+        assertThat(secondCollect).containsExactly(
+            Data(
+                value = StringWrapper("three-1"),
+                origin = Cache
+            ),
+            Data(
+                value = StringWrapper("three-1"),
+                origin = Persister
+            ),
+            Data(
+                value = StringWrapper("three-2"),
+                origin = Fetcher
+            )
+        )
+        collection.cancelAndJoin()
     }
 
     suspend fun Store<Int, String>.get(request: StoreRequest<Int>) =

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
@@ -90,7 +90,7 @@ class FlowStoreTest {
             )
         assertThat(
             pipeline.stream(StoreRequest.cached(3, refresh = false))
-                .take(1) // TODO remove when Issue #59 is fixed.
+                .take(1)
         )
             .emitsExactly(
                 Data(

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
@@ -447,6 +447,7 @@ class FlowStoreTest {
                 )
             )
     }
+
     data class StringWrapper(val wrapped: String)
 
     @Test
@@ -501,7 +502,7 @@ class FlowStoreTest {
         val persister = InMemoryPersister<Int, String>()
         val pipeline = build(
             nonFlowingFetcher = fetcher::fetch,
-            persisterReader = { key -> persister.read(key)?.let {StringWrapper(it)} },
+            persisterReader = { key -> persister.read(key)?.let { StringWrapper(it) } },
             persisterWriter = persister::write,
             enableCache = true
         )

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
@@ -449,190 +449,194 @@ class FlowStoreTest {
     }
 
     @Test
-    fun avoidRefresh_withoutSourceOfTruth() = testScope.runBlockingTest {
-        val fetcher = FakeFetcher(
-            3 to "three-1",
-            3 to "three-2"
-        )
-        val pipeline = build<Int, String, String>(
-            nonFlowingFetcher = fetcher::fetch,
-            enableCache = true
-        )
-        val firstFetch = pipeline.fresh(3)
-        assertThat(firstFetch).isEqualTo("three-1")
-        val secondCollect = mutableListOf<StoreResponse<String>>()
-        val collection = launch {
-            pipeline.stream(StoreRequest.cached(3, refresh = false)).collect {
-                secondCollect.add(it)
+    fun `GIVEN no sourceOfTruth and cache hit WHEN stream cached data without refresh THEN no fetch is triggered AND receives following network updates`() =
+        testScope.runBlockingTest {
+            val fetcher = FakeFetcher(
+                3 to "three-1",
+                3 to "three-2"
+            )
+            val store = build<Int, String, String>(
+                nonFlowingFetcher = fetcher::fetch,
+                enableCache = true
+            )
+            val firstFetch = store.fresh(3)
+            assertThat(firstFetch).isEqualTo("three-1")
+            val secondCollect = mutableListOf<StoreResponse<String>>()
+            val collection = launch {
+                store.stream(StoreRequest.cached(3, refresh = false)).collect {
+                    secondCollect.add(it)
+                }
             }
+            testScope.runCurrent()
+            assertThat(secondCollect).containsExactly(
+                Data(
+                    value = "three-1",
+                    origin = Cache
+                )
+            )
+            // trigger another fetch from network
+            val secondFetch = store.fresh(3)
+            assertThat(secondFetch).isEqualTo("three-2")
+            testScope.runCurrent()
+            // make sure cached also received it
+            assertThat(secondCollect).containsExactly(
+                Data(
+                    value = "three-1",
+                    origin = Cache
+                ),
+                Data(
+                    value = "three-2",
+                    origin = Fetcher
+                )
+            )
+            collection.cancelAndJoin()
         }
-        testScope.runCurrent()
-        assertThat(secondCollect).containsExactly(
-            Data(
-                value = "three-1",
-                origin = Cache
-            )
-        )
-        // trigger another fetch from network
-        val secondFetch = pipeline.fresh(3)
-        assertThat(secondFetch).isEqualTo("three-2")
-        testScope.runCurrent()
-        // make sure cached also received it
-        assertThat(secondCollect).containsExactly(
-            Data(
-                value = "three-1",
-                origin = Cache
-            ),
-            Data(
-                value = "three-2",
-                origin = Fetcher
-            )
-        )
-        collection.cancelAndJoin()
-    }
 
     @Test
-    fun avoidRefresh_withSourceOfTruth() = testScope.runBlockingTest {
-        val fetcher = FakeFetcher(
-            3 to "three-1",
-            3 to "three-2"
-        )
-        val persister = InMemoryPersister<Int, String>()
-        val pipeline = build(
-            nonFlowingFetcher = fetcher::fetch,
-            persisterReader = persister::read,
-            persisterWriter = persister::write,
-            enableCache = true
-        )
-        val firstFetch = pipeline.fresh(3)
-        assertThat(firstFetch).isEqualTo("three-1")
-        val secondCollect = mutableListOf<StoreResponse<String>>()
-        val collection = launch {
-            pipeline.stream(StoreRequest.cached(3, refresh = false)).collect {
-                secondCollect.add(it)
+    fun `GIVEN sourceOfTruth and cache hit WHEN stream cached data without refresh THEN no fetch is triggered AND receives following network updates`() =
+        testScope.runBlockingTest {
+            val fetcher = FakeFetcher(
+                3 to "three-1",
+                3 to "three-2"
+            )
+            val persister = InMemoryPersister<Int, String>()
+            val pipeline = build(
+                nonFlowingFetcher = fetcher::fetch,
+                persisterReader = persister::read,
+                persisterWriter = persister::write,
+                enableCache = true
+            )
+            val firstFetch = pipeline.fresh(3)
+            assertThat(firstFetch).isEqualTo("three-1")
+            val secondCollect = mutableListOf<StoreResponse<String>>()
+            val collection = launch {
+                pipeline.stream(StoreRequest.cached(3, refresh = false)).collect {
+                    secondCollect.add(it)
+                }
             }
+            testScope.runCurrent()
+            assertThat(secondCollect).containsExactly(
+                Data(
+                    value = "three-1",
+                    origin = Cache
+                ),
+                Data(
+                    value = "three-1",
+                    origin = Persister
+                )
+            )
+            // trigger another fetch from network
+            val secondFetch = pipeline.fresh(3)
+            assertThat(secondFetch).isEqualTo("three-2")
+            testScope.runCurrent()
+            // make sure cached also received it
+            assertThat(secondCollect).containsExactly(
+                Data(
+                    value = "three-1",
+                    origin = Cache
+                ),
+                Data(
+                    value = "three-1",
+                    origin = Persister
+                ),
+                Data(
+                    value = "three-2",
+                    origin = Fetcher
+                )
+            )
+            collection.cancelAndJoin()
         }
-        testScope.runCurrent()
-        assertThat(secondCollect).containsExactly(
-            Data(
-                value = "three-1",
-                origin = Cache
-            ),
-            Data(
-                value = "three-1",
-                origin = Persister
-            )
-        )
-        // trigger another fetch from network
-        val secondFetch = pipeline.fresh(3)
-        assertThat(secondFetch).isEqualTo("three-2")
-        testScope.runCurrent()
-        // make sure cached also received it
-        assertThat(secondCollect).containsExactly(
-            Data(
-                value = "three-1",
-                origin = Cache
-            ),
-            Data(
-                value = "three-1",
-                origin = Persister
-            ),
-            Data(
-                value = "three-2",
-                origin = Fetcher
-            )
-        )
-        collection.cancelAndJoin()
-    }
 
     @Test
-    fun withCachedTwoStreamers() = testScope.runBlockingTest {
-        val fetcher = FakeFetcher(
-            3 to "three-1",
-            3 to "three-2"
-        )
-        val pipeline = build<Int, String, String>(
-            nonFlowingFetcher = fetcher::fetch,
-            enableCache = true
-        )
-        val fetcher1Collected = mutableListOf<StoreResponse<String>>()
-        val fetcher1Job = async {
-            pipeline.stream(StoreRequest.cached(3, refresh = true)).collect {
-                fetcher1Collected.add(it)
+    fun `GIVEN cache and no sourceOfTruth WHEN 3 cached streams with refresh AND 1st has a slow collection THEN 1st streams gets 3 fetch updates AND other streams get cache result AND fetch result`() =
+        testScope.runBlockingTest {
+            val fetcher = FakeFetcher(
+                3 to "three-1",
+                3 to "three-2",
+                3 to "three-3"
+            )
+            val pipeline = build<Int, String, String>(
+                nonFlowingFetcher = fetcher::fetch,
+                enableCache = true
+            )
+            val fetcher1Collected = mutableListOf<StoreResponse<String>>()
+            val fetcher1Job = async {
+                pipeline.stream(StoreRequest.cached(3, refresh = true)).collect {
+                    fetcher1Collected.add(it)
+                    delay(1_000)
+                }
             }
+            testScope.advanceUntilIdle()
+            assertThat(fetcher1Collected).isEqualTo(
+                listOf(
+                    Loading<String>(origin = Fetcher),
+                    Data(origin = Fetcher, value = "three-1")
+                )
+            )
+            assertThat(pipeline.stream(StoreRequest.cached(3, refresh = true)))
+                .emitsExactly(
+                    Data(origin = Cache, value = "three-1"),
+                    Loading(origin = Fetcher),
+                    Data(origin = Fetcher, value = "three-2")
+                )
+            assertThat(pipeline.stream(StoreRequest.cached(3, refresh = true)))
+                .emitsExactly(
+                    Data(origin = Cache, value = "three-2"),
+                    Loading(origin = Fetcher),
+                    Data(origin = Fetcher, value = "three-3")
+                )
+            testScope.advanceUntilIdle()
+            assertThat(fetcher1Collected).isEqualTo(
+                listOf(
+                    Loading<String>(origin = Fetcher),
+                    Data(origin = Fetcher, value = "three-1"),
+                    Data(origin = Fetcher, value = "three-2"),
+                    Data(origin = Fetcher, value = "three-3")
+                )
+            )
+            fetcher1Job.cancelAndJoin()
         }
-        testScope.runCurrent()
-        assertThat(fetcher1Collected).isEqualTo(
-            listOf(
-                Loading<String>(origin = Fetcher),
-                Data(origin = Fetcher, value = "three-1")
-            )
-        )
-        assertThat(pipeline.stream(StoreRequest.cached(3, refresh = true)))
-            .emitsExactly(
-                Data(origin = Cache, value = "three-1"),
-                Loading(origin = Fetcher),
-                Data(origin = Fetcher, value = "three-2")
-            )
-        testScope.runCurrent()
-        assertThat(fetcher1Collected).isEqualTo(
-            listOf(
-                Loading<String>(origin = Fetcher),
-                Data(origin = Fetcher, value = "three-1"),
-                Data(origin = Fetcher, value = "three-2")
-            )
-        )
-        fetcher1Job.cancelAndJoin()
-    }
 
     @Test
-    fun withCachedTwoStreamers_slowCollectorReceivesAllNewValues() = testScope.runBlockingTest {
-        val fetcher = FakeFetcher(
-            3 to "three-1",
-            3 to "three-2",
-            3 to "three-3"
-        )
-        val pipeline = build<Int, String, String>(
-            nonFlowingFetcher = fetcher::fetch,
-            enableCache = true
-        )
-        val fetcher1Collected = mutableListOf<StoreResponse<String>>()
-        val fetcher1Job = async {
-            pipeline.stream(StoreRequest.cached(3, refresh = true)).collect {
-                fetcher1Collected.add(it)
-                delay(1_000)
+    fun `GIVEN cache and no sourceOfTruth WHEN 2 cached streams with refresh THEN first streams gets 2 fetch updates AND 2nd stream gets cache result and fetch result`() =
+        testScope.runBlockingTest {
+            val fetcher = FakeFetcher(
+                3 to "three-1",
+                3 to "three-2"
+            )
+            val pipeline = build<Int, String, String>(
+                nonFlowingFetcher = fetcher::fetch,
+                enableCache = true
+            )
+            val fetcher1Collected = mutableListOf<StoreResponse<String>>()
+            val fetcher1Job = async {
+                pipeline.stream(StoreRequest.cached(3, refresh = true)).collect {
+                    fetcher1Collected.add(it)
+                }
             }
+            testScope.runCurrent()
+            assertThat(fetcher1Collected).isEqualTo(
+                listOf(
+                    Loading<String>(origin = Fetcher),
+                    Data(origin = Fetcher, value = "three-1")
+                )
+            )
+            assertThat(pipeline.stream(StoreRequest.cached(3, refresh = true)))
+                .emitsExactly(
+                    Data(origin = Cache, value = "three-1"),
+                    Loading(origin = Fetcher),
+                    Data(origin = Fetcher, value = "three-2")
+                )
+            testScope.runCurrent()
+            assertThat(fetcher1Collected).isEqualTo(
+                listOf(
+                    Loading<String>(origin = Fetcher),
+                    Data(origin = Fetcher, value = "three-1"),
+                    Data(origin = Fetcher, value = "three-2")
+                )
+            )
+            fetcher1Job.cancelAndJoin()
         }
-        testScope.advanceUntilIdle()
-        assertThat(fetcher1Collected).isEqualTo(
-            listOf(
-                Loading<String>(origin = Fetcher),
-                Data(origin = Fetcher, value = "three-1")
-            )
-        )
-        assertThat(pipeline.stream(StoreRequest.cached(3, refresh = true)))
-            .emitsExactly(
-                Data(origin = Cache, value = "three-1"),
-                Loading(origin = Fetcher),
-                Data(origin = Fetcher, value = "three-2")
-            )
-        assertThat(pipeline.stream(StoreRequest.cached(3, refresh = true)))
-            .emitsExactly(
-                Data(origin = Cache, value = "three-2"),
-                Loading(origin = Fetcher),
-                Data(origin = Fetcher, value = "three-3")
-            )
-        testScope.advanceUntilIdle()
-        assertThat(fetcher1Collected).isEqualTo(
-            listOf(
-                Loading<String>(origin = Fetcher),
-                Data(origin = Fetcher, value = "three-1"),
-                Data(origin = Fetcher, value = "three-2"),
-                Data(origin = Fetcher, value = "three-3")
-            )
-        )
-        fetcher1Job.cancelAndJoin()
-    }
 
     suspend fun Store<Int, String>.get(request: StoreRequest<Int>) =
         this.stream(request).filter { it.dataOrNull() != null }.first()

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
@@ -548,7 +548,7 @@ class FlowStoreTest {
         }
 
     @Test
-    fun `GIVEN cache and no sourceOfTruth WHEN 3 cached streams with refresh AND 1st has a slow collection THEN 1st streams gets 3 fetch updates AND other streams get cache result AND fetch result`() =
+    fun `GIVEN cache and no sourceOfTruth WHEN 3 cached streams with refresh AND 1st has slow collection THEN 1st streams gets 3 fetch updates AND other streams get cache result AND fetch result`() =
         testScope.runBlockingTest {
             val fetcher = FakeFetcher(
                 3 to "three-1",


### PR DESCRIPTION
multicaster already has the concept of piggyback only downstream - which are downstream that are carried over after an upstream was closed to be emitted by a following one. This pr updates the multicaster's API to allow to add a downstream at piggyback state directly and uses that in order to fix #59. This now allows us to "listen" to a fetcher without triggering a fetch when not needed.