### PR TITLE
Don't call fetcher if not requested

### DIFF
--- a/store/src/main/java/com/dropbox/android/external/store4/impl/CacheSourceOfTruth.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/CacheSourceOfTruth.kt
@@ -19,6 +19,7 @@ package com.dropbox.android.external.store4.impl
 import com.dropbox.android.external.cache4.Cache
 import com.dropbox.android.external.store4.ResponseOrigin
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
@@ -39,6 +40,7 @@ class CacheSourceOfTruth<Key : Any, Output : Any>(
         }
     )
 
+    @UseExperimental(FlowPreview::class)
     override fun reader(key: Key): Flow<Output?> {
         return flow {
             keyTrackers.use(key) { channel ->

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/CacheSourceOfTruth.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/CacheSourceOfTruth.kt
@@ -26,8 +26,14 @@ import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 
+/**
+ * A [SourceOfTruth] implementation that wraps a cache.
+ *
+ * This is used by the [RealStore] when there is no persister but cache is enabled.This way,
+ * active streams see all new values even if they were fetched for other streams.
+ */
 @UseExperimental(ExperimentalCoroutinesApi::class)
-class CacheSourceOfTruth<Key : Any, Output : Any>(
+internal class CacheSourceOfTruth<Key : Any, Output : Any>(
     private val cache: Cache<Key, Output>
 ) : SourceOfTruth<Key, Output, Output> {
     private val keyTrackers = RefCountedResource<Key, ConflatedBroadcastChannel<Output?>>(

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/CacheSourceOfTruth.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/CacheSourceOfTruth.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dropbox.android.external.store4.impl
+
+import com.dropbox.android.external.cache4.Cache
+import com.dropbox.android.external.store4.ResponseOrigin
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.ConflatedBroadcastChannel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+
+@UseExperimental(ExperimentalCoroutinesApi::class)
+class CacheSourceOfTruth<Key : Any, Output : Any>(
+    private val cache: Cache<Key, Output>
+) : SourceOfTruth<Key, Output, Output> {
+    private val keyTrackers = RefCountedResource<Key, ConflatedBroadcastChannel<Output?>>(
+        create = {
+            // source of truth is expected to send null if it does not have data.
+            ConflatedBroadcastChannel(cache.get(it))
+        },
+        onRelease = { key, channel ->
+            channel.close()
+        }
+    )
+
+    override fun reader(key: Key): Flow<Output?> {
+        return flow {
+            keyTrackers.use(key) { channel ->
+                emitAll(channel.asFlow())
+            }
+        }
+    }
+
+    override suspend fun write(key: Key, value: Output) {
+        keyTrackers.use(key) {
+            cache.put(key, value)
+            it.send(value)
+        }
+    }
+
+    override suspend fun delete(key: Key) {
+        keyTrackers.use(key) {
+            cache.invalidate(key)
+            it.send(null)
+        }
+    }
+
+    override suspend fun getSize() = keyTrackers.size()
+
+    override val defaultOrigin = ResponseOrigin.Cache
+}

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/SourceOfTruthWithBarrier.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/SourceOfTruthWithBarrier.kt
@@ -52,6 +52,9 @@ internal class SourceOfTruthWithBarrier<Key, Input, Output>(
      */
     private val versionCounter = AtomicLong(0)
 
+    val defaultOrigin: ResponseOrigin
+        get() = delegate.defaultOrigin
+
     fun reader(key: Key, lock: CompletableDeferred<Unit>): Flow<DataWithOrigin<Output>> {
         return flow {
             val barrier = barriers.acquire(key)

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
@@ -24,13 +24,10 @@ import com.dropbox.android.external.store4.StoreRequest
 import com.dropbox.android.external.store4.StoreResponse
 import com.dropbox.android.external.store4.StoreResponse.Data
 import com.dropbox.android.external.store4.StoreResponse.Loading
-import com.google.common.truth.Truth
+import com.dropbox.android.external.store4.fresh
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -38,7 +35,6 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineScope
@@ -459,7 +455,7 @@ class FlowStoreTest {
             nonFlowingFetcher = fetcher::fetch,
             enableCache = true
         )
-        val firstFetch = pipeline.fresh(3).requireData()
+        val firstFetch = pipeline.fresh(3)
         assertThat(firstFetch).isEqualTo("three-1")
         val secondCollect = mutableListOf<StoreResponse<String>>()
         val collection = launch {
@@ -475,7 +471,7 @@ class FlowStoreTest {
             )
         )
         // trigger another fetch from network
-        val secondFetch = pipeline.fresh(3).requireData()
+        val secondFetch = pipeline.fresh(3)
         assertThat(secondFetch).isEqualTo("three-2")
         testScope.runCurrent()
         // make sure cached also received it
@@ -505,7 +501,7 @@ class FlowStoreTest {
             persisterWriter = persister::write,
             enableCache = true
         )
-        val firstFetch = pipeline.fresh(3).requireData()
+        val firstFetch = pipeline.fresh(3)
         assertThat(firstFetch).isEqualTo("three-1")
         val secondCollect = mutableListOf<StoreResponse<String>>()
         val collection = launch {
@@ -525,7 +521,7 @@ class FlowStoreTest {
             )
         )
         // trigger another fetch from network
-        val secondFetch = pipeline.fresh(3).requireData()
+        val secondFetch = pipeline.fresh(3)
         assertThat(secondFetch).isEqualTo("three-2")
         testScope.runCurrent()
         // make sure cached also received it
@@ -545,7 +541,6 @@ class FlowStoreTest {
         )
         collection.cancelAndJoin()
     }
-
 
     suspend fun Store<Int, String>.get(request: StoreRequest<Int>) =
         this.stream(request).filter { it.dataOrNull() != null }.first()

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
@@ -474,6 +474,21 @@ class FlowStoreTest {
                 origin = Cache
             )
         )
+        // trigger another fetch from network
+        val secondFetch = pipeline.fresh(3).requireData()
+        assertThat(secondFetch).isEqualTo("three-2")
+        testScope.runCurrent()
+        // make sure cached also received it
+        assertThat(secondCollect).containsExactly(
+            Data(
+                value = "three-1",
+                origin = Cache
+            ),
+            Data(
+                value = "three-2",
+                origin = Fetcher
+            )
+        )
         collection.cancelAndJoin()
     }
 
@@ -507,6 +522,25 @@ class FlowStoreTest {
             Data(
                 value = "three-1",
                 origin = Persister
+            )
+        )
+        // trigger another fetch from network
+        val secondFetch = pipeline.fresh(3).requireData()
+        assertThat(secondFetch).isEqualTo("three-2")
+        testScope.runCurrent()
+        // make sure cached also received it
+        assertThat(secondCollect).containsExactly(
+            Data(
+                value = "three-1",
+                origin = Cache
+            ),
+            Data(
+                value = "three-1",
+                origin = Persister
+            ),
+            Data(
+                value = "three-2",
+                origin = Fetcher
             )
         )
         collection.cancelAndJoin()

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
@@ -26,8 +26,10 @@ import com.dropbox.android.external.store4.StoreResponse.Data
 import com.dropbox.android.external.store4.StoreResponse.Loading
 import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
@@ -36,6 +38,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineScope
@@ -89,10 +92,7 @@ class FlowStoreTest {
                     origin = Fetcher
                 )
             )
-        assertThat(
-            pipeline.stream(StoreRequest.cached(3, refresh = false))
-                .take(1) // TODO remove when Issue #59 is fixed.
-        )
+        assertThat(pipeline.stream(StoreRequest.cached(3, refresh = false)))
             .emitsExactly(
                 Data(
                     value = "three-2",


### PR DESCRIPTION
This PR fixes a bug where we would always call fetcher even when only the cached data is requested.