### PR TITLE
Fix ConcurrentModificationException during Cache eviction

### DIFF
--- a/cache/src/main/kotlin/com/dropbox/android/external/cache4/RealCache.kt
+++ b/cache/src/main/kotlin/com/dropbox/android/external/cache4/RealCache.kt
@@ -215,12 +215,12 @@ internal class RealCache<Key : Any, Value : Any>(
         cleanUpDeadEntries()
 
         while (cacheEntries.size > maxSize) {
-            val entryToEvict = synchronized(accessQueue) {
-                accessQueue.first()
+            val entryToEvict = synchronized(accessQueue) { accessQueue.firstOrNull() }
+            entryToEvict?.run {
+                cacheEntries.remove(entryToEvict.key)
+                writeQueue?.remove(entryToEvict)
+                accessQueue.remove(entryToEvict)
             }
-            cacheEntries.remove(entryToEvict.key)
-            writeQueue?.remove(entryToEvict)
-            accessQueue.remove(entryToEvict)
         }
     }
 

--- a/cache/src/main/kotlin/com/dropbox/android/external/cache4/RealCache.kt
+++ b/cache/src/main/kotlin/com/dropbox/android/external/cache4/RealCache.kt
@@ -215,7 +215,9 @@ internal class RealCache<Key : Any, Value : Any>(
         cleanUpDeadEntries()
 
         while (cacheEntries.size > maxSize) {
-            val entryToEvict = accessQueue.first()
+            val entryToEvict = synchronized(accessQueue) {
+                accessQueue.first()
+            }
             cacheEntries.remove(entryToEvict.key)
             writeQueue?.remove(entryToEvict)
             accessQueue.remove(entryToEvict)

--- a/cache/src/test/kotlin/com/dropbox/android/external/cache4/CacheEvictionTest.kt
+++ b/cache/src/test/kotlin/com/dropbox/android/external/cache4/CacheEvictionTest.kt
@@ -1,6 +1,8 @@
 package com.dropbox.android.external.cache4
 
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 
 class CacheEvictionTest {
@@ -167,5 +169,19 @@ class CacheEvictionTest {
 
         assertThat(cache.get(2))
             .isNull()
+    }
+
+    @Test
+    fun `cache entry eviction can happen concurrently`() = runBlocking {
+        val cache = Cache.Builder.newBuilder()
+            .maximumCacheSize(2)
+            .build<Long, String>()
+
+        // this should not produce a ConcurrentModificationException
+        repeat(20) {
+            launch(newSingleThreadDispatcher()) {
+                cache.put(it.toLong(), "value for $it")
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #89.

PR fixes a `ConcurrentModificationException` during cache eviction due to iterating over the `accessQueue` when calling `accessQueue.first()` without synchronizing the `accessQueue` (MutableSet).

Manually verified that the exception is no longer thrown after pressing "REPEAT TEST" multiple times in the [sample app](https://github.com/atonamy/store4-issue).
