### PR TITLE
Start tracking API binary compatibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,4 +38,5 @@ Small pull requests for things like typos, bugfixes, etc are always welcome.
 
 Please note that we will not accept pull requests for style changes.
 
-
+We use the [binary-compatibility-validator plugin](https://github.com/Kotlin/binary-compatibility-validator) for tracking the binary compatibility of the APIs we ship.
+If your change implies changes to any public API, run `./gradlew apiDump` to generate the updated API dumps and commit those changes.

--- a/build.gradle
+++ b/build.gradle
@@ -6,20 +6,23 @@ buildscript {
         }
         google()
         jcenter()
+        maven { url "https://kotlin.bintray.com/kotlinx" }
     }
 
     ext.versions = [
-            androidGradlePlugin : '4.0.0-alpha09',
-            kotlin              : '1.3.61',
-            dokkaGradlePlugin   : '0.10.0',
-            ktlintGradle        : '9.1.1',
-            spotlessGradlePlugin: '3.26.1',
-            jacocoGradlePlugin  : '0.8.5'
+            androidGradlePlugin         : '4.0.0-alpha09',
+            kotlin                      : '1.3.61',
+            dokkaGradlePlugin           : '0.10.0',
+            ktlintGradle                : '9.1.1',
+            spotlessGradlePlugin        : '3.26.1',
+            jacocoGradlePlugin          : '0.8.5',
+            binaryCompatibilityValidator: '0.1.1',
     ]
 
     dependencies {
         classpath "com.android.tools.build:gradle:${versions.androidGradlePlugin}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
+        classpath "org.jetbrains.kotlinx:binary-compatibility-validator:${versions.binaryCompatibilityValidator}"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokkaGradlePlugin}"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:${versions.ktlintGradle}"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:${versions.spotlessGradlePlugin}"
@@ -28,6 +31,12 @@ buildscript {
 }
 
 apply from: 'buildsystem/dependencies.gradle'
+
+apply plugin: 'binary-compatibility-validator'
+
+apiValidation {
+    ignoredProjects += ["app"]
+}
 
 allprojects {
     repositories {

--- a/cache/api/cache.api
+++ b/cache/api/cache.api
@@ -1,0 +1,26 @@
+public abstract interface class com/dropbox/android/external/cache4/Cache {
+	public abstract fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun get (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public abstract fun invalidate (Ljava/lang/Object;)V
+	public abstract fun invalidateAll ()V
+	public abstract fun put (Ljava/lang/Object;Ljava/lang/Object;)V
+}
+
+public abstract interface class com/dropbox/android/external/cache4/Cache$Builder {
+	public static final field Companion Lcom/dropbox/android/external/cache4/Cache$Builder$Companion;
+	public abstract fun build ()Lcom/dropbox/android/external/cache4/Cache;
+	public abstract fun clock (Lcom/dropbox/android/external/cache4/Clock;)Lcom/dropbox/android/external/cache4/Cache$Builder;
+	public abstract fun concurrencyLevel (I)Lcom/dropbox/android/external/cache4/Cache$Builder;
+	public abstract fun expireAfterAccess (JLjava/util/concurrent/TimeUnit;)Lcom/dropbox/android/external/cache4/Cache$Builder;
+	public abstract fun expireAfterWrite (JLjava/util/concurrent/TimeUnit;)Lcom/dropbox/android/external/cache4/Cache$Builder;
+	public abstract fun maximumCacheSize (J)Lcom/dropbox/android/external/cache4/Cache$Builder;
+}
+
+public final class com/dropbox/android/external/cache4/Cache$Builder$Companion {
+	public final fun newBuilder ()Lcom/dropbox/android/external/cache4/Cache$Builder;
+}
+
+public abstract interface class com/dropbox/android/external/cache4/Clock {
+	public abstract fun getCurrentTimeNanos ()J
+}
+

--- a/filesystem/api/filesystem.api
+++ b/filesystem/api/filesystem.api
@@ -1,0 +1,197 @@
+public abstract interface class com/dropbox/android/external/fs3/AllPersister : com/dropbox/android/external/fs3/DiskAllErase, com/dropbox/android/external/fs3/DiskAllRead, com/dropbox/android/external/store4/Persister {
+	public abstract fun deleteAll (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun read (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun readAll (Lkotlinx/coroutines/CoroutineScope;Ljava/lang/String;)Lkotlinx/coroutines/channels/ReceiveChannel;
+	public abstract fun write (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/dropbox/android/external/fs3/BarCodePathResolver : com/dropbox/android/external/fs3/PathResolver {
+	public static final field INSTANCE Lcom/dropbox/android/external/fs3/BarCodePathResolver;
+	public fun resolve (Lcom/dropbox/android/external/store4/legacy/BarCode;)Ljava/lang/String;
+	public synthetic fun resolve (Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class com/dropbox/android/external/fs3/BarCodeReadAllPathResolver : com/dropbox/android/external/fs3/PathResolver {
+	public static final field INSTANCE Lcom/dropbox/android/external/fs3/BarCodeReadAllPathResolver;
+	public fun resolve (Lcom/dropbox/android/external/store4/legacy/BarCode;)Ljava/lang/String;
+	public synthetic fun resolve (Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public abstract interface class com/dropbox/android/external/fs3/BufferedSourceAdapter {
+	public abstract fun toJson (Ljava/lang/Object;)Lokio/BufferedSource;
+}
+
+public abstract interface class com/dropbox/android/external/fs3/DiskAllErase {
+	public abstract fun deleteAll (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/dropbox/android/external/fs3/DiskAllRead {
+	public abstract fun readAll (Lkotlinx/coroutines/CoroutineScope;Ljava/lang/String;)Lkotlinx/coroutines/channels/ReceiveChannel;
+}
+
+public abstract interface class com/dropbox/android/external/fs3/DiskErase {
+	public abstract fun delete (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/dropbox/android/external/fs3/FSAllEraser : com/dropbox/android/external/fs3/DiskAllErase {
+	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;)V
+	public fun deleteAll (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/dropbox/android/external/fs3/FSAllReader : com/dropbox/android/external/fs3/DiskAllRead {
+	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;)V
+	public fun readAll (Lkotlinx/coroutines/CoroutineScope;Ljava/lang/String;)Lkotlinx/coroutines/channels/ReceiveChannel;
+}
+
+public final class com/dropbox/android/external/fs3/FSEraser : com/dropbox/android/external/fs3/DiskErase {
+	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;)V
+	public fun delete (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/dropbox/android/external/fs3/FSReader : com/dropbox/android/external/store4/DiskRead {
+	public static final field Companion Lcom/dropbox/android/external/fs3/FSReader$Companion;
+	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;)V
+	public fun read (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/dropbox/android/external/fs3/FSReader$Companion {
+}
+
+public class com/dropbox/android/external/fs3/FSWriter : com/dropbox/android/external/store4/DiskWrite {
+	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;)V
+	public synthetic fun write (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun write (Ljava/lang/Object;Lokio/BufferedSource;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/dropbox/android/external/fs3/FileSystemPersister : com/dropbox/android/external/store4/Persister {
+	public static final field Companion Lcom/dropbox/android/external/fs3/FileSystemPersister$Companion;
+	public synthetic fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun read (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun write (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun write (Ljava/lang/Object;Lokio/BufferedSource;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/dropbox/android/external/fs3/FileSystemPersister$Companion {
+	public final fun create (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;)Lcom/dropbox/android/external/store4/Persister;
+}
+
+public final class com/dropbox/android/external/fs3/FileSystemRecordPersister : com/dropbox/android/external/fs3/RecordProvider, com/dropbox/android/external/store4/Persister {
+	public static final field Companion Lcom/dropbox/android/external/fs3/FileSystemRecordPersister$Companion;
+	public synthetic fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;JLjava/util/concurrent/TimeUnit;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getRecordState (Ljava/lang/Object;)Lcom/dropbox/android/external/fs3/RecordState;
+	public fun read (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun write (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun write (Ljava/lang/Object;Lokio/BufferedSource;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/dropbox/android/external/fs3/FileSystemRecordPersister$Companion {
+	public final fun create (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;JLjava/util/concurrent/TimeUnit;)Lcom/dropbox/android/external/fs3/FileSystemRecordPersister;
+}
+
+public abstract interface class com/dropbox/android/external/fs3/PathResolver {
+	public abstract fun resolve (Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class com/dropbox/android/external/fs3/RecordPersister : com/dropbox/android/external/fs3/SourcePersister, com/dropbox/android/external/fs3/RecordProvider {
+	public static final field Companion Lcom/dropbox/android/external/fs3/RecordPersister$Companion;
+	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;JLjava/util/concurrent/TimeUnit;)V
+	public fun getRecordState (Lcom/dropbox/android/external/store4/legacy/BarCode;)Lcom/dropbox/android/external/fs3/RecordState;
+	public synthetic fun getRecordState (Ljava/lang/Object;)Lcom/dropbox/android/external/fs3/RecordState;
+}
+
+public final class com/dropbox/android/external/fs3/RecordPersister$Companion {
+	public final fun create (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;JLjava/util/concurrent/TimeUnit;)Lcom/dropbox/android/external/fs3/RecordPersister;
+}
+
+public final class com/dropbox/android/external/fs3/RecordPersisterFactory {
+	public static final field INSTANCE Lcom/dropbox/android/external/fs3/RecordPersisterFactory;
+	public final fun create (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;JLjava/util/concurrent/TimeUnit;)Lcom/dropbox/android/external/store4/Persister;
+	public final fun create (Ljava/io/File;JLjava/util/concurrent/TimeUnit;)Lcom/dropbox/android/external/store4/Persister;
+}
+
+public abstract interface class com/dropbox/android/external/fs3/RecordProvider {
+	public abstract fun getRecordState (Ljava/lang/Object;)Lcom/dropbox/android/external/fs3/RecordState;
+}
+
+public final class com/dropbox/android/external/fs3/RecordState : java/lang/Enum {
+	public static final field FRESH Lcom/dropbox/android/external/fs3/RecordState;
+	public static final field MISSING Lcom/dropbox/android/external/fs3/RecordState;
+	public static final field STALE Lcom/dropbox/android/external/fs3/RecordState;
+	public static fun valueOf (Ljava/lang/String;)Lcom/dropbox/android/external/fs3/RecordState;
+	public static fun values ()[Lcom/dropbox/android/external/fs3/RecordState;
+}
+
+public final class com/dropbox/android/external/fs3/SourceAllPersister : com/dropbox/android/external/fs3/AllPersister {
+	public static final field Companion Lcom/dropbox/android/external/fs3/SourceAllPersister$Companion;
+	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;)V
+	public fun deleteAll (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun read (Lcom/dropbox/android/external/store4/legacy/BarCode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun read (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAll (Lkotlinx/coroutines/CoroutineScope;Ljava/lang/String;)Lkotlinx/coroutines/channels/ReceiveChannel;
+	public fun write (Lcom/dropbox/android/external/store4/legacy/BarCode;Lokio/BufferedSource;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun write (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/dropbox/android/external/fs3/SourceAllPersister$Companion {
+	public final fun create (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;)Lcom/dropbox/android/external/fs3/SourceAllPersister;
+}
+
+public final class com/dropbox/android/external/fs3/SourceFileReader : com/dropbox/android/external/fs3/FSReader, com/dropbox/android/external/store4/DiskRead {
+	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;)V
+	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;)V
+	public synthetic fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getRecordState (Lcom/dropbox/android/external/store4/legacy/BarCode;Ljava/util/concurrent/TimeUnit;J)Lcom/dropbox/android/external/fs3/RecordState;
+}
+
+public final class com/dropbox/android/external/fs3/SourceFileWriter : com/dropbox/android/external/fs3/FSWriter, com/dropbox/android/external/store4/DiskWrite {
+	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;)V
+	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;)V
+	public synthetic fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public class com/dropbox/android/external/fs3/SourcePersister : com/dropbox/android/external/store4/Persister {
+	public static final field Companion Lcom/dropbox/android/external/fs3/SourcePersister$Companion;
+	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;)V
+	protected final fun getSourceFileReader ()Lcom/dropbox/android/external/fs3/SourceFileReader;
+	protected final fun getSourceFileWriter ()Lcom/dropbox/android/external/fs3/SourceFileWriter;
+	public fun read (Lcom/dropbox/android/external/store4/legacy/BarCode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun read (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun write (Lcom/dropbox/android/external/store4/legacy/BarCode;Lokio/BufferedSource;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun write (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/dropbox/android/external/fs3/SourcePersister$Companion {
+	public final fun create (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;)Lcom/dropbox/android/external/fs3/SourcePersister;
+}
+
+public final class com/dropbox/android/external/fs3/SourcePersisterFactory {
+	public static final field INSTANCE Lcom/dropbox/android/external/fs3/SourcePersisterFactory;
+	public final fun create (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;)Lcom/dropbox/android/external/store4/Persister;
+	public final fun create (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;JLjava/util/concurrent/TimeUnit;)Lcom/dropbox/android/external/store4/Persister;
+	public final fun create (Ljava/io/File;)Lcom/dropbox/android/external/store4/Persister;
+	public final fun create (Ljava/io/File;JLjava/util/concurrent/TimeUnit;)Lcom/dropbox/android/external/store4/Persister;
+	public final fun createAll (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;)Lcom/dropbox/android/external/store4/Persister;
+	public final fun createAll (Ljava/io/File;)Lcom/dropbox/android/external/store4/Persister;
+}
+
+public final class com/dropbox/android/external/fs3/Util {
+	public static final field INSTANCE Lcom/dropbox/android/external/fs3/Util;
+	public final fun createParentDirs (Ljava/io/File;)V
+	public final fun simplifyPath (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public abstract interface class com/dropbox/android/external/fs3/filesystem/FileSystem {
+	public abstract fun delete (Ljava/lang/String;)V
+	public abstract fun deleteAll (Ljava/lang/String;)V
+	public abstract fun exists (Ljava/lang/String;)Z
+	public abstract fun getRecordState (Ljava/util/concurrent/TimeUnit;JLjava/lang/String;)Lcom/dropbox/android/external/fs3/RecordState;
+	public abstract fun list (Ljava/lang/String;)Ljava/util/Collection;
+	public abstract fun read (Ljava/lang/String;)Lokio/BufferedSource;
+	public abstract fun write (Ljava/lang/String;Lokio/BufferedSource;)V
+}
+
+public final class com/dropbox/android/external/fs3/filesystem/FileSystemFactory {
+	public static final field INSTANCE Lcom/dropbox/android/external/fs3/filesystem/FileSystemFactory;
+	public final fun create (Ljava/io/File;)Lcom/dropbox/android/external/fs3/filesystem/FileSystem;
+}
+

--- a/multicast/api/multicast.api
+++ b/multicast/api/multicast.api
@@ -1,0 +1,8 @@
+public final class com/dropbox/flow/multicast/Multicaster {
+	public fun <init> (Lkotlinx/coroutines/CoroutineScope;ILkotlinx/coroutines/flow/Flow;ZZLkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Lkotlinx/coroutines/CoroutineScope;ILkotlinx/coroutines/flow/Flow;ZZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun newDownstream (Z)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun newDownstream$default (Lcom/dropbox/flow/multicast/Multicaster;ZILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+

--- a/store-rx2/api/store-rx2.api
+++ b/store-rx2/api/store-rx2.api
@@ -1,0 +1,13 @@
+public final class com/dropbox/store/rx2/RxStoreKt {
+	public static final fun fromFlowable (Lcom/dropbox/android/external/store4/StoreBuilder$Companion;Lkotlin/jvm/functions/Function1;)Lcom/dropbox/android/external/store4/StoreBuilder;
+	public static final fun fromSingle (Lcom/dropbox/android/external/store4/StoreBuilder$Companion;Lkotlin/jvm/functions/Function1;)Lcom/dropbox/android/external/store4/StoreBuilder;
+	public static final fun observe (Lcom/dropbox/android/external/store4/Store;Lcom/dropbox/android/external/store4/StoreRequest;)Lio/reactivex/Flowable;
+	public static final fun observeClear (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;)Lio/reactivex/Completable;
+	public static final fun observeClearAll (Lcom/dropbox/android/external/store4/Store;)Lio/reactivex/Completable;
+	public static final fun withFlowablePersister (Lcom/dropbox/android/external/store4/StoreBuilder;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Lcom/dropbox/android/external/store4/StoreBuilder;
+	public static synthetic fun withFlowablePersister$default (Lcom/dropbox/android/external/store4/StoreBuilder;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/dropbox/android/external/store4/StoreBuilder;
+	public static final fun withScheduler (Lcom/dropbox/android/external/store4/StoreBuilder;Lio/reactivex/Scheduler;)Lcom/dropbox/android/external/store4/StoreBuilder;
+	public static final fun withSinglePersister (Lcom/dropbox/android/external/store4/StoreBuilder;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Lcom/dropbox/android/external/store4/StoreBuilder;
+	public static synthetic fun withSinglePersister$default (Lcom/dropbox/android/external/store4/StoreBuilder;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/dropbox/android/external/store4/StoreBuilder;
+}
+

--- a/store/api/store.api
+++ b/store/api/store.api
@@ -1,0 +1,161 @@
+public abstract interface class com/dropbox/android/external/store4/DiskRead {
+	public abstract fun read (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/dropbox/android/external/store4/DiskWrite {
+	public abstract fun write (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface annotation class com/dropbox/android/external/store4/ExperimentalStoreApi : java/lang/annotation/Annotation {
+}
+
+public final class com/dropbox/android/external/store4/MemoryPolicy {
+	public static final field Companion Lcom/dropbox/android/external/store4/MemoryPolicy$Companion;
+	public static final field DEFAULT_POLICY J
+	public final fun getExpireAfterAccess ()J
+	public final fun getExpireAfterTimeUnit ()Ljava/util/concurrent/TimeUnit;
+	public final fun getExpireAfterWrite ()J
+	public final fun getHasAccessPolicy ()Z
+	public final fun getHasMaxSize ()Z
+	public final fun getHasWritePolicy ()Z
+	public final fun getMaxSize ()J
+	public final fun isDefaultWritePolicy ()Z
+}
+
+public final class com/dropbox/android/external/store4/MemoryPolicy$Companion {
+	public final fun builder ()Lcom/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder;
+}
+
+public final class com/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder {
+	public fun <init> ()V
+	public final fun build ()Lcom/dropbox/android/external/store4/MemoryPolicy;
+	public final fun setExpireAfterAccess (J)Lcom/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder;
+	public final fun setExpireAfterTimeUnit (Ljava/util/concurrent/TimeUnit;)Lcom/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder;
+	public final fun setExpireAfterWrite (J)Lcom/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder;
+	public final fun setMemorySize (J)Lcom/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder;
+}
+
+public abstract interface class com/dropbox/android/external/store4/Persister : com/dropbox/android/external/store4/DiskRead, com/dropbox/android/external/store4/DiskWrite {
+	public abstract fun read (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun write (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/dropbox/android/external/store4/ResponseOrigin : java/lang/Enum {
+	public static final field Cache Lcom/dropbox/android/external/store4/ResponseOrigin;
+	public static final field Fetcher Lcom/dropbox/android/external/store4/ResponseOrigin;
+	public static final field Persister Lcom/dropbox/android/external/store4/ResponseOrigin;
+	public static fun valueOf (Ljava/lang/String;)Lcom/dropbox/android/external/store4/ResponseOrigin;
+	public static fun values ()[Lcom/dropbox/android/external/store4/ResponseOrigin;
+}
+
+public abstract interface class com/dropbox/android/external/store4/Store {
+	public abstract fun clear (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun clearAll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun stream (Lcom/dropbox/android/external/store4/StoreRequest;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/dropbox/android/external/store4/StoreBuilder {
+	public static final field Companion Lcom/dropbox/android/external/store4/StoreBuilder$Companion;
+	public abstract fun build ()Lcom/dropbox/android/external/store4/Store;
+	public abstract fun cachePolicy (Lcom/dropbox/android/external/store4/MemoryPolicy;)Lcom/dropbox/android/external/store4/StoreBuilder;
+	public abstract fun disableCache ()Lcom/dropbox/android/external/store4/StoreBuilder;
+	public abstract fun nonFlowingPersister (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lcom/dropbox/android/external/store4/StoreBuilder;
+	public abstract fun nonFlowingPersisterLegacy (Lcom/dropbox/android/external/store4/Persister;)Lcom/dropbox/android/external/store4/StoreBuilder;
+	public abstract fun persister (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lcom/dropbox/android/external/store4/StoreBuilder;
+	public abstract fun scope (Lkotlinx/coroutines/CoroutineScope;)Lcom/dropbox/android/external/store4/StoreBuilder;
+}
+
+public final class com/dropbox/android/external/store4/StoreBuilder$Companion {
+	public final fun from (Lkotlin/jvm/functions/Function1;)Lcom/dropbox/android/external/store4/StoreBuilder;
+	public final fun fromNonFlow (Lkotlin/jvm/functions/Function2;)Lcom/dropbox/android/external/store4/StoreBuilder;
+}
+
+public final class com/dropbox/android/external/store4/StoreBuilder$DefaultImpls {
+	public static synthetic fun nonFlowingPersister$default (Lcom/dropbox/android/external/store4/StoreBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/dropbox/android/external/store4/StoreBuilder;
+	public static synthetic fun persister$default (Lcom/dropbox/android/external/store4/StoreBuilder;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/dropbox/android/external/store4/StoreBuilder;
+}
+
+public final class com/dropbox/android/external/store4/StoreKt {
+	public static final fun fresh (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun get (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun stream (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/dropbox/android/external/store4/StoreRequest {
+	public static final field Companion Lcom/dropbox/android/external/store4/StoreRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/Object;IZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/Object;IZ)Lcom/dropbox/android/external/store4/StoreRequest;
+	public static synthetic fun copy$default (Lcom/dropbox/android/external/store4/StoreRequest;Ljava/lang/Object;IZILjava/lang/Object;)Lcom/dropbox/android/external/store4/StoreRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/Object;
+	public final fun getRefresh ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/dropbox/android/external/store4/StoreRequest$Companion {
+	public final fun cached (Ljava/lang/Object;Z)Lcom/dropbox/android/external/store4/StoreRequest;
+	public final fun fresh (Ljava/lang/Object;)Lcom/dropbox/android/external/store4/StoreRequest;
+	public final fun skipMemory (Ljava/lang/Object;Z)Lcom/dropbox/android/external/store4/StoreRequest;
+}
+
+public abstract class com/dropbox/android/external/store4/StoreResponse {
+	public final fun dataOrNull ()Ljava/lang/Object;
+	public final fun errorOrNull ()Ljava/lang/Throwable;
+	public abstract fun getOrigin ()Lcom/dropbox/android/external/store4/ResponseOrigin;
+	public final fun requireData ()Ljava/lang/Object;
+	public final fun throwIfError ()V
+}
+
+public final class com/dropbox/android/external/store4/StoreResponse$Data : com/dropbox/android/external/store4/StoreResponse {
+	public fun <init> (Ljava/lang/Object;Lcom/dropbox/android/external/store4/ResponseOrigin;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Lcom/dropbox/android/external/store4/ResponseOrigin;
+	public final fun copy (Ljava/lang/Object;Lcom/dropbox/android/external/store4/ResponseOrigin;)Lcom/dropbox/android/external/store4/StoreResponse$Data;
+	public static synthetic fun copy$default (Lcom/dropbox/android/external/store4/StoreResponse$Data;Ljava/lang/Object;Lcom/dropbox/android/external/store4/ResponseOrigin;ILjava/lang/Object;)Lcom/dropbox/android/external/store4/StoreResponse$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getOrigin ()Lcom/dropbox/android/external/store4/ResponseOrigin;
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/dropbox/android/external/store4/StoreResponse$Error : com/dropbox/android/external/store4/StoreResponse {
+	public fun <init> (Ljava/lang/Throwable;Lcom/dropbox/android/external/store4/ResponseOrigin;)V
+	public final fun component1 ()Ljava/lang/Throwable;
+	public final fun component2 ()Lcom/dropbox/android/external/store4/ResponseOrigin;
+	public final fun copy (Ljava/lang/Throwable;Lcom/dropbox/android/external/store4/ResponseOrigin;)Lcom/dropbox/android/external/store4/StoreResponse$Error;
+	public static synthetic fun copy$default (Lcom/dropbox/android/external/store4/StoreResponse$Error;Ljava/lang/Throwable;Lcom/dropbox/android/external/store4/ResponseOrigin;ILjava/lang/Object;)Lcom/dropbox/android/external/store4/StoreResponse$Error;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getError ()Ljava/lang/Throwable;
+	public fun getOrigin ()Lcom/dropbox/android/external/store4/ResponseOrigin;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/dropbox/android/external/store4/StoreResponse$Loading : com/dropbox/android/external/store4/StoreResponse {
+	public fun <init> (Lcom/dropbox/android/external/store4/ResponseOrigin;)V
+	public final fun component1 ()Lcom/dropbox/android/external/store4/ResponseOrigin;
+	public final fun copy (Lcom/dropbox/android/external/store4/ResponseOrigin;)Lcom/dropbox/android/external/store4/StoreResponse$Loading;
+	public static synthetic fun copy$default (Lcom/dropbox/android/external/store4/StoreResponse$Loading;Lcom/dropbox/android/external/store4/ResponseOrigin;ILjava/lang/Object;)Lcom/dropbox/android/external/store4/StoreResponse$Loading;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getOrigin ()Lcom/dropbox/android/external/store4/ResponseOrigin;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/dropbox/android/external/store4/legacy/BarCode {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/dropbox/android/external/store4/legacy/BarCode;
+	public static synthetic fun copy$default (Lcom/dropbox/android/external/store4/legacy/BarCode;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/dropbox/android/external/store4/legacy/BarCode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+


### PR DESCRIPTION
This PR introduces the [binary-compatibility-validator plugin](https://github.com/Kotlin/binary-compatibility-validator) for tracking binary compatibility of our public APIs.

The plugin has 2 gradle tasks:

- `./gradlew apiDump` - generates the API dump files for the current public API. When we intend to make changes to the public API we need to run this command and commit the updated API dumps.
- `./gradlew apiCheck` - builds the projects and verifies that the current public APIs are consistent with the API dump files (baseline).  This is automatically added to the `check` task.

Resolves #96.