### PR TITLE
Fix gradle wrapper version.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,10 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-<<<<<<< Updated upstream
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
-||||||| merged common ancestors
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-milestone-2-all.zip
-=======
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-rc-1-all.zip
->>>>>>> Stashed changes


### PR DESCRIPTION
@digitalbuddha Looks like people are finding this annoying after all 😅. Should we stick to the latest stable release for Gradle wrapper?