### PR TITLE
Fix CodeCov by changing gradle-wrapper to 6.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,10 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-<<<<<<< Updated upstream
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
-||||||| merged common ancestors
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-milestone-2-all.zip
-=======
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-rc-1-all.zip
->>>>>>> Stashed changes

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,10 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+<<<<<<< Updated upstream
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+||||||| merged common ancestors
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-milestone-2-all.zip
+=======
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-rc-1-all.zip
+>>>>>>> Stashed changes


### PR DESCRIPTION
Don't understand why codecov broke on this, but a git bisect pointed to updating the wrapper to 6.1.1 to be the culprit.

Test Plan: Code Cov posts to this PR.