### PR TITLE
Ensure network starts after disk is established

### DIFF
--- a/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/RxSingleStoreTest.kt
+++ b/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/RxSingleStoreTest.kt
@@ -50,7 +50,7 @@ class RxSingleStoreTest {
                     Completable.complete()
                 }
             )
-            .withScheduler(Schedulers.io())
+            .withScheduler(Schedulers.trampoline())
             .build()
 
     @Test

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
@@ -164,7 +164,8 @@ internal class RealStore<Key : Any, Input : Any, Output : Any>(
         val diskFlow = sourceOfTruth.reader(request.key, diskLock)
         // we use a merge implementation that gives the source of the flow so that we can decide
         // based on that.
-        return networkFlow.merge(diskFlow.withIndex().onStart {
+        return networkFlow.merge(diskFlow.withIndex()
+                                         .onStart {
             // wait for disk to latch first to ensure it happens before network triggers.
             // after that, if we'll not read from disk, then allow network to continue
             if (request.shouldSkipCache(CacheType.DISK)) {


### PR DESCRIPTION
This PR fixes a bug in the ordering where if disk is skipped and network
is super fast, there is a tiny chance that we wouldn't latch onto source
of truth before triggering network and that would make SourceOfTruth think
that the value was written to disk before it observed, hence become a disk
value rather than fetcher.

This PR ensures that we unlock the network only after we establish a position
in the disk read queue so that we'll know the fetcher value came afterwards.

Fixes: #114
Test: RxSingleStoreTest
