### PR TITLE
Fix typo in RxStore

### DIFF
--- a/store-rx2/src/main/kotlin/com/dropbox/store/rx2/RxStore.kt
+++ b/store-rx2/src/main/kotlin/com/dropbox/store/rx2/RxStore.kt
@@ -91,7 +91,7 @@ fun <Key : Any, Output : Any> StoreBuilder<Key, Output>.withScheduler(
  * Connects a (Non Flow) [Single] source of truth that is accessible via [reader], [writer],
  * [delete], and [deleteAll].
  *
- * @see persister
+ * @see com.dropbox.android.external.store4.StoreBuilder.persister
  */
 @FlowPreview
 @ExperimentalCoroutinesApi

--- a/store-rx2/src/main/kotlin/com/dropbox/store/rx2/RxStore.kt
+++ b/store-rx2/src/main/kotlin/com/dropbox/store/rx2/RxStore.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.rx2.await
 import kotlinx.coroutines.rx2.rxCompletable
 
 /**
- * Return a flow for the given key
+ * Return a [Flowable] for the given key
  * @param request - see [StoreRequest] for configurations
  */
 @ExperimentalCoroutinesApi


### PR DESCRIPTION
Two small changes to the KDoc in RxStore. One to avoid confusion between Coroutine Flows and RxJava Flowables. The other to fix an IDE warning about not being able to find `persister` because it is a function in another class.