### PR TITLE
Make SharedFlowProducer APIs safe

### DIFF
--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/SharedFlowProducer.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/SharedFlowProducer.kt
@@ -69,10 +69,8 @@ internal class SharedFlowProducer<T>(
     fun start() {
         scope.launch {
             try {
-                // start the collection
-                collectionJob.start()
-                // wait until collection ends, either due to an error or ordered by the channel
-                // manager
+                // trigger start of the collection and wait until collection ends, either due to an
+                // error or ordered by the channel manager
                 collectionJob.join()
             } finally {
                 // cleanup the channel manager so that downstreams can be closed if they are not

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/SharedFlowProducerTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/SharedFlowProducerTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dropbox.flow.multicast
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.junit.Test
+
+@UseExperimental(ExperimentalCoroutinesApi::class)
+class SharedFlowProducerTest {
+    private val scope = TestCoroutineScope()
+    private val upstreamMessages = mutableListOf<String>()
+    private fun createProducer(flow: Flow<String>) = SharedFlowProducer<String>(
+        scope = scope,
+        src = flow,
+        sendUpsteamMessage = {
+            if (it is ChannelManager.Message.Dispatch.Value) {
+                upstreamMessages.add(it.value)
+                it.delivered.complete(Unit)
+            }
+        }
+    )
+
+    @Test
+    fun `Closing producer before it starts should not crash or consume flow`() {
+        val producer = createProducer(flowOf("a", "b", "c"))
+        scope.pauseDispatcher()
+        producer.start()
+        producer.cancel()
+        assertThat(upstreamMessages).isEmpty()
+    }
+
+    @Test
+    fun `Producer forwards all values from source when acked`() {
+        val producer = createProducer(flowOf("a", "b", "c"))
+        assertThat(upstreamMessages).isEmpty()
+        producer.start()
+        assertThat(upstreamMessages).containsExactly("a", "b", "c")
+    }
+
+    @Test
+    fun `Calling start should be idempotent`() {
+        val producer = createProducer(flowOf("a", "b", "c"))
+        assertThat(upstreamMessages).isEmpty()
+        producer.start()
+        producer.start()
+        producer.start()
+        assertThat(upstreamMessages).containsExactly("a", "b", "c")
+    }
+}


### PR DESCRIPTION
This PR fixes a bug in SharedFlowProducer where it would not handle start being called
multiple times or cancel being called before start is completed. It could even consume
the upstream flow multiple times if start is called multiple times.

Fixes: #120
Test: SharedFlowProducerTest
