### PR TITLE
Add `asMap` function to Cache for backward compat

### DIFF
--- a/cache/api/cache.api
+++ b/cache/api/cache.api
@@ -1,4 +1,5 @@
 public abstract interface class com/dropbox/android/external/cache4/Cache {
+	public abstract fun asMap ()Ljava/util/Map;
 	public abstract fun get (Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun get (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public abstract fun invalidate (Ljava/lang/Object;)V

--- a/cache/src/main/kotlin/com/dropbox/android/external/cache4/Cache.kt
+++ b/cache/src/main/kotlin/com/dropbox/android/external/cache4/Cache.kt
@@ -44,6 +44,11 @@ interface Cache<in Key : Any, Value : Any> {
     fun invalidateAll()
 
     /**
+     * Returns a defensive copy of cache entries as [Map]
+     */
+    fun asMap(): Map<in Key, Value>
+
+    /**
      * Main entry point for creating a [Cache].
      */
     interface Builder {

--- a/cache/src/main/kotlin/com/dropbox/android/external/cache4/RealCache.kt
+++ b/cache/src/main/kotlin/com/dropbox/android/external/cache4/RealCache.kt
@@ -1,6 +1,7 @@
 package com.dropbox.android.external.cache4
 
 import java.util.Collections
+import java.util.Collections.unmodifiableMap
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -161,6 +162,10 @@ internal class RealCache<Key : Any, Value : Any>(
         cacheEntries.clear()
         writeQueue?.clear()
         accessQueue?.clear()
+    }
+
+    override fun asMap(): Map<in Key, Value> {
+        return Collections.unmodifiableMap(cacheEntries.mapValues { (_, entry) -> entry.value })
     }
 
     /**

--- a/cache/src/test/kotlin/com/dropbox/android/external/cache4/DefaultCacheTest.kt
+++ b/cache/src/test/kotlin/com/dropbox/android/external/cache4/DefaultCacheTest.kt
@@ -156,4 +156,16 @@ class DefaultCacheTest {
         assertThat(cache.get(Unit))
             .isEqualTo("cat")
     }
+
+    @Test
+    fun `asMap() returns all entries`() {
+        val cache = Cache.Builder.newBuilder()
+            .build<Long, String>()
+
+        cache.put(1, "dog")
+        cache.put(2, "cat")
+
+        assertThat(cache.asMap())
+            .isEqualTo(mapOf(1L to "dog", 2L to "cat"))
+    }
 }


### PR DESCRIPTION
The original Cache Java implementation had `asMap` function returning the Cache entries as a Map. Adding that feature back to Store 4.