### PR TITLE
Small: Remove Collections.unmodifiableMap

### DIFF
--- a/cache/src/main/kotlin/com/dropbox/android/external/cache4/RealCache.kt
+++ b/cache/src/main/kotlin/com/dropbox/android/external/cache4/RealCache.kt
@@ -1,7 +1,6 @@
 package com.dropbox.android.external.cache4
 
 import java.util.Collections
-import java.util.Collections.unmodifiableMap
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
@@ -169,7 +168,7 @@ internal class RealCache<Key : Any, Value : Any>(
     }
 
     override fun asMap(): Map<in Key, Value> {
-        return Collections.unmodifiableMap(cacheEntries.mapValues { (_, entry) -> entry.value })
+        return cacheEntries.mapValues { (_, entry) -> entry.value }
     }
 
     /**

--- a/cache/src/test/kotlin/com/dropbox/android/external/cache4/DefaultCacheTest.kt
+++ b/cache/src/test/kotlin/com/dropbox/android/external/cache4/DefaultCacheTest.kt
@@ -168,4 +168,18 @@ class DefaultCacheTest {
         assertThat(cache.asMap())
             .isEqualTo(mapOf(1L to "dog", 2L to "cat"))
     }
+    
+    @Test
+    fun `asMap() creates a defensive copy`() {
+        val cache = Cache.Builder.newBuilder()
+            .build<Long, String>()
+
+        cache.put(1, "dog")
+        cache.put(2, "cat")
+
+        val map = cache.asMap() as MutableMap
+        map[3] = "bird"
+
+        assertThat(cache.get(3)).isNull()
+    }
 }

--- a/cache/src/test/kotlin/com/dropbox/android/external/cache4/DefaultCacheTest.kt
+++ b/cache/src/test/kotlin/com/dropbox/android/external/cache4/DefaultCacheTest.kt
@@ -168,7 +168,6 @@ class DefaultCacheTest {
         assertThat(cache.asMap())
             .isEqualTo(mapOf(1L to "dog", 2L to "cat"))
     }
-    
     @Test
     fun `asMap() creates a defensive copy`() {
         val cache = Cache.Builder.newBuilder()


### PR DESCRIPTION
Remove unnecessary Collections.unmodifiableMap since we already return a defensive copy. Also write test to verify we returns a copy
