### PR TITLE
Fix mangled function names for Java users

### DIFF
--- a/app/src/main/java/com/dropbox/android/sample/Graph.kt
+++ b/app/src/main/java/com/dropbox/android/sample/Graph.kt
@@ -28,10 +28,9 @@ import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import java.io.File
 import java.io.IOException
-import kotlin.time.ExperimentalTime
 import kotlin.time.seconds
 
-@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class, ExperimentalTime::class, ExperimentalStdlibApi::class)
+@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class, ExperimentalStdlibApi::class)
 object Graph {
     private val moshi = Moshi.Builder().build()
 

--- a/app/src/main/java/com/dropbox/android/sample/ui/stream/StreamFragment.kt
+++ b/app/src/main/java/com/dropbox/android/sample/ui/stream/StreamFragment.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.flow.flattenMerge
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
-import kotlin.time.ExperimentalTime
 import kotlin.time.seconds
 
 @ExperimentalCoroutinesApi
@@ -41,7 +40,6 @@ class StreamFragment : Fragment(), CoroutineScope {
         return inflater.inflate(R.layout.fragment_stream, container, false)
     }
 
-    @ExperimentalTime
     @ExperimentalStdlibApi
     @InternalCoroutinesApi
     @FlowPreview

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     ext.versions = [
-            androidGradlePlugin         : '4.0.0-beta03',
+            androidGradlePlugin         : '4.0.0-beta04',
             kotlin                      : '1.3.70',
             dokkaGradlePlugin           : '0.10.0',
             ktlintGradle                : '9.1.1',
@@ -98,5 +98,12 @@ subprojects {
 
     project.plugins.withType(com.android.build.gradle.AppPlugin).whenPluginAdded(preDexClosure)
     project.plugins.withType(com.android.build.gradle.LibraryPlugin).whenPluginAdded(preDexClosure)
+
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
+        kotlinOptions {
+            jvmTarget = "1.8"
+            freeCompilerArgs += '-Xopt-in=kotlin.time.ExperimentalTime'
+        }
+    }
 }
 

--- a/cache/build.gradle
+++ b/cache/build.gradle
@@ -26,14 +26,3 @@ apply from: rootProject.file("gradle/maven-push.gradle")
 apply from: rootProject.file("gradle/jacoco.gradle")
 targetCompatibility = 1.8
 sourceCompatibility = 1.8
-
-compileKotlin {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}
-compileTestKotlin {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}

--- a/cache/src/main/kotlin/com/dropbox/android/external/cache4/Cache.kt
+++ b/cache/src/main/kotlin/com/dropbox/android/external/cache4/Cache.kt
@@ -1,7 +1,6 @@
 package com.dropbox.android.external.cache4
 
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 
 /**
  * An in-memory key-value store with support for time-based (expiration) and size-based evictions.
@@ -61,7 +60,6 @@ interface Cache<in Key : Any, Value : Any> {
          * When [duration] is zero, the cache's max size will be set to 0
          * meaning no values will be cached.
          */
-        @ExperimentalTime
         fun expireAfterWrite(duration: Duration): Builder
 
         /**
@@ -72,7 +70,6 @@ interface Cache<in Key : Any, Value : Any> {
          * When [duration] is zero, the cache's max size will be set to 0
          * meaning no values will be cached.
          */
-        @ExperimentalTime
         fun expireAfterAccess(duration: Duration): Builder
 
         /**
@@ -123,15 +120,12 @@ interface Cache<in Key : Any, Value : Any> {
  */
 internal class CacheBuilderImpl : Cache.Builder {
 
-    @ExperimentalTime
     private var expireAfterWriteDuration = Duration.INFINITE
-    @ExperimentalTime
     private var expireAfterAccessDuration = Duration.INFINITE
     private var maxSize = UNSET_LONG
     private var concurrencyLevel = DEFAULT_CONCURRENCY_LEVEL
     private var clock: Clock? = null
 
-    @ExperimentalTime
     override fun expireAfterWrite(duration: Duration): CacheBuilderImpl = apply {
         require(duration.isPositive()) {
             "expireAfterWrite duration must be positive"
@@ -139,7 +133,6 @@ internal class CacheBuilderImpl : Cache.Builder {
         this.expireAfterWriteDuration = duration
     }
 
-    @ExperimentalTime
     override fun expireAfterAccess(duration: Duration): CacheBuilderImpl = apply {
         require(duration.isPositive()) {
             "expireAfterAccess duration must be positive"
@@ -165,7 +158,6 @@ internal class CacheBuilderImpl : Cache.Builder {
         this.clock = clock
     }
 
-    @ExperimentalTime
     override fun <K : Any, V : Any> build(): Cache<K, V> {
         return RealCache(
             expireAfterWriteDuration,

--- a/cache/src/main/kotlin/com/dropbox/android/external/cache4/RealCache.kt
+++ b/cache/src/main/kotlin/com/dropbox/android/external/cache4/RealCache.kt
@@ -3,7 +3,6 @@ package com.dropbox.android.external.cache4
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 import kotlin.time.nanoseconds
 
 /**
@@ -27,7 +26,6 @@ import kotlin.time.nanoseconds
  * Size-based evictions are enabled by specifying [maxSize]. When the size of the cache entries grows
  * beyond [maxSize], least recently accessed entries will be evicted.
  */
-@ExperimentalTime
 internal class RealCache<Key : Any, Value : Any>(
     val expireAfterWriteDuration: Duration,
     val expireAfterAccessDuration: Duration,

--- a/cache/src/test/kotlin/com/dropbox/android/external/cache4/CacheBuilderTest.kt
+++ b/cache/src/test/kotlin/com/dropbox/android/external/cache4/CacheBuilderTest.kt
@@ -6,11 +6,9 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.assertThrows
 import org.junit.Test
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 import kotlin.time.hours
 import kotlin.time.nanoseconds
 
-@ExperimentalTime
 class CacheBuilderTest {
 
     @Test

--- a/cache/src/test/kotlin/com/dropbox/android/external/cache4/CacheExpirationTest.kt
+++ b/cache/src/test/kotlin/com/dropbox/android/external/cache4/CacheExpirationTest.kt
@@ -3,11 +3,9 @@ package com.dropbox.android.external.cache4
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 import kotlin.time.minutes
 import kotlin.time.nanoseconds
 
-@ExperimentalTime
 class CacheExpirationTest {
 
     private val clock = TestClock(virtualDuration = 0.nanoseconds)

--- a/cache/src/test/kotlin/com/dropbox/android/external/cache4/CacheInvalidationTest.kt
+++ b/cache/src/test/kotlin/com/dropbox/android/external/cache4/CacheInvalidationTest.kt
@@ -2,11 +2,9 @@ package com.dropbox.android.external.cache4
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
-import kotlin.time.ExperimentalTime
 import kotlin.time.minutes
 import kotlin.time.nanoseconds
 
-@ExperimentalTime
 class CacheInvalidationTest {
 
     @Test

--- a/cache/src/test/kotlin/com/dropbox/android/external/cache4/CacheLoaderTest.kt
+++ b/cache/src/test/kotlin/com/dropbox/android/external/cache4/CacheLoaderTest.kt
@@ -10,11 +10,9 @@ import org.junit.Assert.assertThrows
 import org.junit.Rule
 import org.junit.Test
 import java.io.IOException
-import kotlin.time.ExperimentalTime
 import kotlin.time.minutes
 import kotlin.time.nanoseconds
 
-@ExperimentalTime
 class CacheLoaderTest {
 
     @Rule

--- a/cache/src/test/kotlin/com/dropbox/android/external/cache4/TestClock.kt
+++ b/cache/src/test/kotlin/com/dropbox/android/external/cache4/TestClock.kt
@@ -1,9 +1,7 @@
 package com.dropbox.android.external.cache4
 
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 
-@ExperimentalTime
 class TestClock(
     @Volatile var virtualDuration: Duration = Duration.INFINITE
 ) : Clock {

--- a/filesystem/src/main/java/com/dropbox/android/external/fs3/FileSystemRecordPersister.kt
+++ b/filesystem/src/main/java/com/dropbox/android/external/fs3/FileSystemRecordPersister.kt
@@ -4,7 +4,6 @@ import com.dropbox.android.external.fs3.filesystem.FileSystem
 import com.dropbox.android.external.store4.Persister
 import okio.BufferedSource
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 
 /**
  * FileSystemRecordPersister is used when persisting to/from file system while being stale aware
@@ -13,7 +12,6 @@ import kotlin.time.ExperimentalTime
  *
  * @param <Key> key type
 </Key> */
-@ExperimentalTime
 class FileSystemRecordPersister<Key> private constructor(
     private val fileSystem: FileSystem,
     private val pathResolver: PathResolver<Key>,

--- a/filesystem/src/main/java/com/dropbox/android/external/fs3/RecordPersister.kt
+++ b/filesystem/src/main/java/com/dropbox/android/external/fs3/RecordPersister.kt
@@ -3,9 +3,7 @@ package com.dropbox.android.external.fs3
 import com.dropbox.android.external.fs3.filesystem.FileSystem
 import com.dropbox.android.external.store4.legacy.BarCode
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 
-@ExperimentalTime
 class RecordPersister(
     fileSystem: FileSystem,
     private val expirationDuration: Duration

--- a/filesystem/src/main/java/com/dropbox/android/external/fs3/RecordPersisterFactory.kt
+++ b/filesystem/src/main/java/com/dropbox/android/external/fs3/RecordPersisterFactory.kt
@@ -8,12 +8,10 @@ import okio.BufferedSource
 import java.io.File
 import java.io.IOException
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 
 /**
  * Factory for [RecordPersister]
  */
-@ExperimentalTime
 object RecordPersisterFactory {
 
     /**

--- a/filesystem/src/main/java/com/dropbox/android/external/fs3/SourceFileReader.kt
+++ b/filesystem/src/main/java/com/dropbox/android/external/fs3/SourceFileReader.kt
@@ -6,14 +6,12 @@ import com.dropbox.android.external.store4.DiskRead
 import com.dropbox.android.external.store4.legacy.BarCode
 import okio.BufferedSource
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 
 class SourceFileReader @JvmOverloads constructor(
     fileSystem: FileSystem,
     pathResolver: PathResolver<BarCode> = BarCodePathResolver
 ) : FSReader<BarCode>(fileSystem, pathResolver), DiskRead<BufferedSource, BarCode> {
 
-    @ExperimentalTime
     fun getRecordState(
         barCode: BarCode,
         expirationDuration: Duration

--- a/filesystem/src/main/java/com/dropbox/android/external/fs3/SourcePersisterFactory.kt
+++ b/filesystem/src/main/java/com/dropbox/android/external/fs3/SourcePersisterFactory.kt
@@ -9,7 +9,6 @@ import okio.BufferedSource
 import java.io.File
 import java.io.IOException
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 
 /**
  * Factory for [SourcePersister]
@@ -24,7 +23,6 @@ object SourcePersisterFactory {
      *
      * @throws IOException
      */
-    @ExperimentalTime
     @Throws(IOException::class)
     fun create(
         root: File,
@@ -37,7 +35,6 @@ object SourcePersisterFactory {
      * Returns a new [BufferedSource] persister with the provided fileSystem as the root of the
      * persistence [FileSystem].
      */
-    @ExperimentalTime
     fun create(
         fileSystem: FileSystem,
         expirationDuration: Duration

--- a/filesystem/src/main/java/com/dropbox/android/external/fs3/filesystem/FileSystem.kt
+++ b/filesystem/src/main/java/com/dropbox/android/external/fs3/filesystem/FileSystem.kt
@@ -6,7 +6,6 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 
 /**
  * a **FileSystem** provides an api to a hierarchal structure of [File]s, which does *not* necessarily
@@ -103,7 +102,6 @@ interface FileSystem {
      * compares age of file with given expiration time and returns
      * appropriate recordState
      */
-    @ExperimentalTime
     fun getRecordState(
         expirationDuration: Duration,
         path: String

--- a/filesystem/src/main/java/com/dropbox/android/external/fs3/filesystem/FileSystemImpl.kt
+++ b/filesystem/src/main/java/com/dropbox/android/external/fs3/filesystem/FileSystemImpl.kt
@@ -8,7 +8,6 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 
 /**
  * implements a [FileSystem] as regular files on disk in a specific document root (kind of like a root jail)
@@ -63,7 +62,6 @@ internal class FileSystemImpl(private val root: File) : FileSystem {
         return getFile(file)!!.exists()
     }
 
-    @ExperimentalTime
     override fun getRecordState(
         expirationDuration: Duration,
         path: String

--- a/filesystem/src/test/java/com/dropbox/android/external/fs3/FileSystemRecordPersisterTest.kt
+++ b/filesystem/src/test/java/com/dropbox/android/external/fs3/FileSystemRecordPersisterTest.kt
@@ -1,20 +1,18 @@
 package com.dropbox.android.external.fs3
 
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
 import com.dropbox.android.external.fs3.filesystem.FileSystem
 import com.dropbox.android.external.store4.legacy.BarCode
-import java.io.FileNotFoundException
-import org.junit.Assert.fail
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.runBlocking
 import okio.BufferedSource
-import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.fail
 import org.junit.Test
 import org.mockito.Mockito.inOrder
-import kotlin.time.ExperimentalTime
+import java.io.FileNotFoundException
 import kotlin.time.days
 
-@ExperimentalTime
 class FileSystemRecordPersisterTest {
     private val fileSystem: FileSystem = mock()
     private val bufferedSource: BufferedSource = mock()

--- a/filesystem/src/test/java/com/dropbox/android/external/fs3/RecordPersisterTest.kt
+++ b/filesystem/src/test/java/com/dropbox/android/external/fs3/RecordPersisterTest.kt
@@ -1,19 +1,17 @@
 package com.dropbox.android.external.fs3
 
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
 import com.dropbox.android.external.fs3.filesystem.FileSystem
 import com.dropbox.android.external.store4.legacy.BarCode
-import java.io.FileNotFoundException
-import org.junit.Assert.fail
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.runBlocking
 import okio.BufferedSource
-import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.fail
 import org.junit.Test
-import kotlin.time.ExperimentalTime
+import java.io.FileNotFoundException
 import kotlin.time.days
 
-@ExperimentalTime
 class RecordPersisterTest {
 
     private val fileSystem: FileSystem = mock()

--- a/filesystem/src/test/java/com/dropbox/android/external/fs3/impl/SimpleTest.kt
+++ b/filesystem/src/test/java/com/dropbox/android/external/fs3/impl/SimpleTest.kt
@@ -5,16 +5,15 @@ import com.dropbox.android.external.fs3.filesystem.FileSystem
 import com.dropbox.android.external.fs3.filesystem.FileSystemFactory
 import com.google.common.base.Charsets.UTF_8
 import com.google.common.io.Files.createTempDir
+import com.google.common.truth.Truth.assertThat
 import okio.BufferedSource
 import okio.buffer
 import okio.source
-import com.google.common.truth.Truth.assertThat
 import org.junit.Before
 import org.junit.Test
 import java.io.ByteArrayInputStream
 import java.io.FileNotFoundException
 import java.io.IOException
-import kotlin.time.ExperimentalTime
 import kotlin.time.days
 import kotlin.time.microseconds
 import kotlin.time.minutes
@@ -54,7 +53,6 @@ class SimpleTest {
         assertThat(fileSystem.exists("/boo")).isFalse()
     }
 
-    @ExperimentalTime
     @Test
     @Throws(IOException::class)
     fun testIsRecordStale() {

--- a/multicast/build.gradle
+++ b/multicast/build.gradle
@@ -18,16 +18,8 @@ apply from: rootProject.file("gradle/jacoco.gradle")
 targetCompatibility = 1.8
 sourceCompatibility = 1.8
 
-compileKotlin {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}
 compileTestKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
-        freeCompilerArgs += [
-                '-Xopt-in=kotlin.RequiresOptIn',
-        ]
+        freeCompilerArgs += '-Xopt-in=kotlin.RequiresOptIn'
     }
 }

--- a/store-rx2/build.gradle
+++ b/store-rx2/build.gradle
@@ -24,16 +24,8 @@ apply from: rootProject.file("gradle/jacoco.gradle")
 targetCompatibility = 1.8
 sourceCompatibility = 1.8
 
-compileKotlin {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}
 compileTestKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
-        freeCompilerArgs += [
-                '-Xopt-in=kotlin.RequiresOptIn',
-        ]
+        freeCompilerArgs += '-Xopt-in=kotlin.RequiresOptIn'
     }
 }

--- a/store/build.gradle
+++ b/store/build.gradle
@@ -39,21 +39,11 @@ repositories {
 }
 compileKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
-        freeCompilerArgs += [
-                '-Xopt-in=kotlin.Experimental',
-        ]
-    }
-}
-compileTestKotlin {
-    kotlinOptions {
-        jvmTarget = "1.8"
         freeCompilerArgs += [
                 '-Xopt-in=kotlin.RequiresOptIn',
         ]
     }
 }
-
 
 dokka {
     outputFormat = 'javadoc'

--- a/store/src/main/java/com/dropbox/android/external/store4/MemoryPolicy.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/MemoryPolicy.kt
@@ -1,7 +1,6 @@
 package com.dropbox.android.external.store4
 
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 
 /**
  * MemoryPolicy holds all required info to create MemoryCache
@@ -14,7 +13,6 @@ import kotlin.time.ExperimentalTime
  * MemoryPolicy is used by a [Store]
  * and defines the in-memory cache behavior.
  */
-@ExperimentalTime
 class MemoryPolicy internal constructor(
     val expireAfterWrite: Duration,
     val expireAfterAccess: Duration,

--- a/store/src/main/java/com/dropbox/android/external/store4/StoreBuilder.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/StoreBuilder.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlin.time.ExperimentalTime
 
 /**
  * Main entry point for creating a [Store].
@@ -49,7 +48,6 @@ interface StoreBuilder<Key : Any, Output : Any> {
      *  or size based eviction
      *  Example: MemoryPolicy.builder().setExpireAfterWrite(10.seconds).build()
      */
-    @ExperimentalTime
     fun cachePolicy(memoryPolicy: MemoryPolicy?): StoreBuilder<Key, Output>
 
     /**
@@ -117,7 +115,6 @@ interface StoreBuilder<Key : Any, Output : Any> {
          *
          * @param fetcher a function for fetching network records.
          */
-        @OptIn(ExperimentalTime::class)
         fun <Key : Any, Output : Any> fromNonFlow(
             fetcher: suspend (key: Key) -> Output
         ): StoreBuilder<Key, Output> = BuilderImpl { key: Key ->
@@ -134,7 +131,6 @@ interface StoreBuilder<Key : Any, Output : Any> {
          *
          * @param fetcher a function for fetching a flow of network records.
          */
-        @OptIn(ExperimentalTime::class)
         fun <Key : Any, Output : Any> from(
             fetcher: (key: Key) -> Flow<Output>
         ): StoreBuilder<Key, Output> = BuilderImpl(fetcher)
@@ -142,7 +138,6 @@ interface StoreBuilder<Key : Any, Output : Any> {
 }
 
 @FlowPreview
-@OptIn(ExperimentalTime::class)
 @ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 private class BuilderImpl<Key : Any, Output : Any>(
@@ -245,7 +240,6 @@ private class BuilderImpl<Key : Any, Output : Any>(
 }
 
 @FlowPreview
-@OptIn(ExperimentalTime::class)
 @ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 private class BuilderWithSourceOfTruth<Key : Any, Input : Any, Output : Any>(

--- a/store/src/main/java/com/dropbox/android/external/store4/StoreDefaults.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/StoreDefaults.kt
@@ -1,10 +1,8 @@
 package com.dropbox.android.external.store4
 
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 import kotlin.time.hours
 
-@ExperimentalTime
 internal object StoreDefaults {
 
     /**

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
@@ -36,9 +36,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.flow.withIndex
-import kotlin.time.ExperimentalTime
 
-@ExperimentalTime
 @ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 @FlowPreview

--- a/store/src/test/java/com/dropbox/android/external/store3/StoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/StoreTest.kt
@@ -26,9 +26,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 
-@ExperimentalTime
 @FlowPreview
 @ExperimentalStdlibApi
 @ExperimentalCoroutinesApi

--- a/store/src/test/java/com/dropbox/android/external/store3/TestStoreBuilder.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/TestStoreBuilder.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.flow
-import kotlin.time.ExperimentalTime
 
 @FlowPreview
 @ExperimentalStdlibApi
@@ -39,7 +38,6 @@ data class TestStoreBuilder<Key : Any, Output : Any>(
         TestStoreType.FlowStore -> buildStore()
     }
 
-    @OptIn(ExperimentalTime::class)
     companion object {
 
         fun <Key : Any, Output : Any> from(

--- a/store/src/test/java/com/dropbox/android/external/store3/base/impl/MemoryPolicyBuilderTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/base/impl/MemoryPolicyBuilderTest.kt
@@ -1,14 +1,10 @@
 package com.dropbox.android.external.store3.base.impl
 
 import com.dropbox.android.external.store4.MemoryPolicy
-
-import org.junit.Test
-
 import com.google.common.truth.Truth.assertThat
-import kotlin.time.ExperimentalTime
+import org.junit.Test
 import kotlin.time.seconds
 
-@ExperimentalTime
 class MemoryPolicyBuilderTest {
 
     @Test


### PR DESCRIPTION
I tried the new alpha in an old codebase that still had Java. When a function is annotated with an Experimental annotation, the Kotlin callers had to the same and that propogates up. For Java users, this is impossible. That's why the name of the function is mangled and hidden to Java caller.

This PR opts into `ExperimentalTime` by using compiler flags instead of the annotation

## Considerations

Time API is experimental. That means at any time Kotlin can decide to change the API and the consumers has to deal with them. What that means for libraries is complex. Whatever you do, if Kotlin break binary compatibility, then Store library will do too.

That gives us 3 options:

### Original version: use the annotation:
- Kotlin users will need to opt-in
- Kotlin users will need to migrate if the Kotlin API changes
- Java users cannot use them

Effort is low. Not easy for users. Has risk of API changes. 

### This PR: complete opt-in
- Kotlin and Java users can immediately use it. 
- They need to migrate if API changes

Effort is low. Most easy for users now. Has risk of API changes. 

### Keep old API

3rd option would be to keep the API along with new duration. 

Effort is high. Easy for all users. Migration for users will also be easy. No risk of API breakage. 