### PR TITLE
Some little Gradle clean-up

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,7 @@
 buildscript {
     repositories {
         mavenCentral()
-        maven {
-            url 'https://plugins.gradle.org/m2/'
-        }
+        gradlePluginPortal()
         google()
         jcenter()
     }
@@ -80,10 +78,6 @@ ext {
     POM_DEVELOPER_NAME = "Dropbox"
 }
 
-
-// From command line use: -PdisablePreDex to disable it: primarily for jenkins
-project.ext.preDexLibs = !project.hasProperty('disablePreDex')
-
 subprojects {
     apply plugin: 'com.diffplug.gradle.spotless'
     spotless {
@@ -91,12 +85,5 @@ subprojects {
             target 'src/**/*.kt'
         }
     }
-
-    def preDexClosure = {
-        project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
-    }
-
-    project.plugins.withType(com.android.build.gradle.AppPlugin).whenPluginAdded(preDexClosure)
-    project.plugins.withType(com.android.build.gradle.LibraryPlugin).whenPluginAdded(preDexClosure)
 }
 


### PR DESCRIPTION
Pre-dex is really outdated and is no longer recommended to disable. The flag was not even used.

`gradlePluginPortal()` function is used. It adds the same maven url.