### PR TITLE
Contain @ExperimentalStdlibApi within relevant scope.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ Change Log
 
 The change log for Store version 1.x can be found [here](https://github.com/NYTimes/Store/blob/develop/CHANGELOG.md).
 
+Version 4.0.0-alpha05 *(2020-04-03)*
+----------------------------
+
+**Bug Fixes and Stability Improvements**
+* Contain @ExperimentalStdlibApi within relevant scope. (#154)
+* Use AtomicFu to replace Java's AtomicBoolean and ReentrantLock (#147)
+* migrate Multicast to Kotlin Test (#146)
+* Remove Collections.unmodifiableMap (#145)
+* Update AGP version (#143)
+* Remove some unneeded java.util packages (#141)
+
 Version 4.0.0-alpha04 *(2020-04-03)*
 ----------------------------
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Artifacts are hosted on **Maven Central**.
 ###### Latest version:
 
 ```groovy
-def store_version = "4.0.0-alpha04"
+def store_version = "4.0.0-alpha05"
 ```
 
 ###### Add the dependency to your `build.gradle`:

--- a/app/src/main/java/com/dropbox/android/sample/ui/stream/StreamFragment.kt
+++ b/app/src/main/java/com/dropbox/android/sample/ui/stream/StreamFragment.kt
@@ -42,7 +42,6 @@ class StreamFragment : Fragment(), CoroutineScope {
     }
 
     @ExperimentalTime
-    @ExperimentalStdlibApi
     @InternalCoroutinesApi
     @FlowPreview
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ allprojects {
 ext {
     // POM file
     GROUP = "com.dropbox.mobile.store"
-    VERSION_NAME = "4.0.0-alpha05"
+    VERSION_NAME = "4.0.0-SNAPSHOT"
     POM_PACKAGING = "pom"
     POM_DESCRIPTION = "Store4 is built with Kotlin Coroutines"
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ allprojects {
 ext {
     // POM file
     GROUP = "com.dropbox.mobile.store"
-    VERSION_NAME = "4.0.0-alpha04"
+    VERSION_NAME = "4.0.0-SNAPSHOT"
     POM_PACKAGING = "pom"
     POM_DESCRIPTION = "Store4 is built with Kotlin Coroutines"
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ allprojects {
 ext {
     // POM file
     GROUP = "com.dropbox.mobile.store"
-    VERSION_NAME = "4.0.0-SNAPSHOT"
+    VERSION_NAME = "4.0.0-alpha04"
     POM_PACKAGING = "pom"
     POM_DESCRIPTION = "Store4 is built with Kotlin Coroutines"
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ allprojects {
 ext {
     // POM file
     GROUP = "com.dropbox.mobile.store"
-    VERSION_NAME = "4.0.0-SNAPSHOT"
+    VERSION_NAME = "4.0.0-alpha05"
     POM_PACKAGING = "pom"
     POM_DESCRIPTION = "Store4 is built with Kotlin Coroutines"
 

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/ChannelManager.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/ChannelManager.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+@file:OptIn(ExperimentalStdlibApi::class)
 package com.dropbox.flow.multicast
 
 import kotlinx.coroutines.CompletableDeferred
@@ -21,6 +21,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
+
+
 
 /**
  * Tracks active downstream channels and dispatches incoming upstream values to each of them in
@@ -31,7 +33,6 @@ import kotlinx.coroutines.flow.Flow
  * is no active upstream and there's at least one downstream that has not received a value.
  *
  */
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 internal class ChannelManager<T>(
     /**
@@ -84,7 +85,6 @@ internal class ChannelManager<T>(
      */
     private inner class Actor : StoreRealActor<Message<T>>(scope) {
 
-        @ExperimentalStdlibApi
         private val buffer = Buffer<T>(bufferSize)
 
         /**
@@ -362,7 +362,6 @@ internal class ChannelManager<T>(
 /**
  * Buffer implementation for any late arrivals.
  */
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 private interface Buffer<T> {
     fun add(item: ChannelManager.Message.Dispatch.Value<T>)
@@ -373,7 +372,6 @@ private interface Buffer<T> {
 /**
  * Default implementation of buffer which does not buffer anything.
  */
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 private class NoBuffer<T> : Buffer<T> {
     override val items: Collection<ChannelManager.Message.Dispatch.Value<T>>
@@ -387,7 +385,6 @@ private class NoBuffer<T> : Buffer<T> {
  * Create a new buffer insteance based on the provided limit.
  */
 @Suppress("FunctionName")
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 private fun <T> Buffer(limit: Int): Buffer<T> = if (limit > 0) {
     BufferImpl(limit)
@@ -398,7 +395,6 @@ private fun <T> Buffer(limit: Int): Buffer<T> = if (limit > 0) {
 /**
  * A real buffer implementation that has a FIFO queue.
  */
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 private class BufferImpl<T>(private val limit: Int) :
     Buffer<T> {
@@ -411,7 +407,6 @@ private class BufferImpl<T>(private val limit: Int) :
     }
 }
 
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 internal fun <T> ChannelManager.Message.Dispatch.Value<T>.markDelivered() =
     delivered.complete(Unit)

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/ChannelManager.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/ChannelManager.kt
@@ -22,8 +22,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
 
-
-
 /**
  * Tracks active downstream channels and dispatches incoming upstream values to each of them in
  * parallel. The upstream is suspended after producing a value until at least one of the downstreams

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/Multicaster.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/Multicaster.kt
@@ -37,7 +37,6 @@ import kotlinx.coroutines.flow.transform
  * is empty.
  */
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 class Multicaster<T>(
     /**

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/SharedFlowProducer.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/SharedFlowProducer.kt
@@ -37,7 +37,6 @@ import kotlinx.coroutines.launch
  * Cancellation of the collection might be triggered by both this producer (e.g. upstream completes)
  * or the [ChannelManager] (e.g. all active collectors complete).
  */
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 internal class SharedFlowProducer<T>(
     private val scope: CoroutineScope,

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerTest.kt
@@ -37,7 +37,6 @@ import kotlin.test.fail
 import kotlin.test.Test
 
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 class ChannelManagerTest {
     private val scope = TestCoroutineScope()

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/InfiniteMulticastTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/InfiniteMulticastTest.kt
@@ -37,7 +37,6 @@ import kotlin.test.assertEquals
  * values as well.
  */
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 class InfiniteMulticastTest {
     private val testScope = TestCoroutineScope()

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/MulticastTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/MulticastTest.kt
@@ -45,7 +45,6 @@ import kotlin.test.assertTrue
 import kotlin.test.assertFailsWith
 
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 class MulticastTest {
     private val testScope = TestCoroutineScope()

--- a/store-rx2/src/main/kotlin/com/dropbox/store/rx2/RxStore.kt
+++ b/store-rx2/src/main/kotlin/com/dropbox/store/rx2/RxStore.kt
@@ -57,7 +57,6 @@ fun <Key : Any, Output : Any> Store<Key, Output>.observeClearAll(): Completable 
  * @param fetcher a function for fetching a flow of network records.
  */
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 fun <Key : Any, Output : Any> StoreBuilder.Companion.fromFlowable(
     fetcher: (key: Key) -> Flowable<Output>
@@ -73,7 +72,6 @@ fun <Key : Any, Output : Any> StoreBuilder.Companion.fromFlowable(
  * @param fetcher a function for fetching a [Single] network response for a [Key]
  */
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 fun <Key : Any, Output : Any> StoreBuilder.Companion.fromSingle(
     fetcher: (key: Key) -> Single<Output>
@@ -85,7 +83,6 @@ fun <Key : Any, Output : Any> StoreBuilder.Companion.fromSingle(
  * if a scheduler is not set Store will use [GlobalScope]
  */
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 fun <Key : Any, Output : Any> StoreBuilder<Key, Output>.withScheduler(
     scheduler: Scheduler
@@ -100,7 +97,6 @@ fun <Key : Any, Output : Any> StoreBuilder<Key, Output>.withScheduler(
  * @see com.dropbox.android.external.store4.StoreBuilder.persister
  */
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 fun <Key : Any, Output : Any, NewOutput : Any> StoreBuilder<Key, Output>.withSinglePersister(
     reader: (Key) -> Maybe<NewOutput>,
@@ -137,7 +133,6 @@ fun <Key : Any, Output : Any, NewOutput : Any> StoreBuilder<Key, Output>.withSin
  *
  */
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 fun <Key : Any, Output : Any, NewOutput : Any> StoreBuilder<Key, Output>.withFlowablePersister(
     reader: (Key) -> Flowable<NewOutput>,

--- a/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/HotRxSingleStoreTest.kt
+++ b/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/HotRxSingleStoreTest.kt
@@ -17,7 +17,6 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 class HotRxSingleStoreTest {
     private val testScope = TestCoroutineScope()

--- a/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/RxFlowableStoreTest.kt
+++ b/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/RxFlowableStoreTest.kt
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicInteger
 
 @RunWith(JUnit4::class)
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 class RxFlowableStoreTest {
     private val atomicInteger = AtomicInteger(0)

--- a/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/RxSingleStoreExtensionsTest.kt
+++ b/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/RxSingleStoreExtensionsTest.kt
@@ -18,7 +18,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import java.util.concurrent.atomic.AtomicInteger
 
-@ExperimentalStdlibApi
 @ExperimentalStoreApi
 @RunWith(JUnit4::class)
 @FlowPreview

--- a/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/RxSingleStoreTest.kt
+++ b/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/RxSingleStoreTest.kt
@@ -22,7 +22,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import java.util.concurrent.atomic.AtomicInteger
 
-@ExperimentalStdlibApi
 @ExperimentalStoreApi
 @RunWith(JUnit4::class)
 @FlowPreview

--- a/store/src/main/java/com/dropbox/android/external/store4/StoreBuilder.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/StoreBuilder.kt
@@ -31,7 +31,6 @@ import kotlin.time.ExperimentalTime
  * Main entry point for creating a [Store].
  */
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 interface StoreBuilder<Key : Any, Output : Any> {
     fun build(): Store<Key, Output>
@@ -143,7 +142,6 @@ interface StoreBuilder<Key : Any, Output : Any> {
 
 @FlowPreview
 @OptIn(ExperimentalTime::class)
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 private class BuilderImpl<Key : Any, Output : Any>(
     private val fetcher: (key: Key) -> Flow<Output>
@@ -246,7 +244,6 @@ private class BuilderImpl<Key : Any, Output : Any>(
 
 @FlowPreview
 @OptIn(ExperimentalTime::class)
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 private class BuilderWithSourceOfTruth<Key : Any, Input : Any, Output : Any>(
     private val fetcher: (key: Key) -> Flow<Input>,

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/FetcherController.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/FetcherController.kt
@@ -36,7 +36,6 @@ import kotlinx.coroutines.flow.map
  * request.
  */
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 internal class FetcherController<Key, Input, Output>(
     /**

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
@@ -39,7 +39,6 @@ import kotlinx.coroutines.flow.withIndex
 import kotlin.time.ExperimentalTime
 
 @ExperimentalTime
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 @FlowPreview
 internal class RealStore<Key : Any, Input : Any, Output : Any>(

--- a/store/src/test/java/com/dropbox/android/external/store3/DontCacheErrorsTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/DontCacheErrorsTest.kt
@@ -12,7 +12,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 @RunWith(Parameterized::class)
 class DontCacheErrorsTest(

--- a/store/src/test/java/com/dropbox/android/external/store3/NoNetworkTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/NoNetworkTest.kt
@@ -14,7 +14,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 @RunWith(Parameterized::class)
 class NoNetworkTest(

--- a/store/src/test/java/com/dropbox/android/external/store3/SequentialTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/SequentialTest.kt
@@ -13,7 +13,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 @RunWith(Parameterized::class)
 class SequentialTest(

--- a/store/src/test/java/com/dropbox/android/external/store3/StoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/StoreTest.kt
@@ -30,7 +30,6 @@ import kotlin.time.ExperimentalTime
 
 @ExperimentalTime
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 @RunWith(Parameterized::class)
 class StoreTest(

--- a/store/src/test/java/com/dropbox/android/external/store3/StoreThrowOnNoItems.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/StoreThrowOnNoItems.kt
@@ -18,7 +18,6 @@ import org.junit.runners.Parameterized
 import java.util.concurrent.atomic.AtomicInteger
 
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 @RunWith(Parameterized::class)
 class StoreThrowOnNoItems(

--- a/store/src/test/java/com/dropbox/android/external/store3/StreamOneKeyTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/StreamOneKeyTest.kt
@@ -25,7 +25,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 @RunWith(Parameterized::class)
 class StreamOneKeyTest(

--- a/store/src/test/java/com/dropbox/android/external/store3/TestStoreBuilder.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/TestStoreBuilder.kt
@@ -30,7 +30,6 @@ import kotlinx.coroutines.flow.flow
 import kotlin.time.ExperimentalTime
 
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 data class TestStoreBuilder<Key : Any, Output : Any>(
     private val buildStore: () -> Store<Key, Output>

--- a/store/src/test/java/com/dropbox/android/external/store4/FetcherControllerTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/FetcherControllerTest.kt
@@ -32,7 +32,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 @FlowPreview
 @RunWith(JUnit4::class)

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/ClearAllStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/ClearAllStoreTest.kt
@@ -16,7 +16,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 @ExperimentalStoreApi
 @RunWith(JUnit4::class)

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/ClearStoreByKeyTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/ClearStoreByKeyTest.kt
@@ -15,7 +15,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 @RunWith(JUnit4::class)
 class ClearStoreByKeyTest {

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
@@ -47,7 +47,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-@ExperimentalStdlibApi
 @FlowPreview
 @ExperimentalCoroutinesApi
 @RunWith(JUnit4::class)

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/HotFlowStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/HotFlowStoreTest.kt
@@ -16,7 +16,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 @FlowPreview
 @RunWith(JUnit4::class)

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/StreamWithoutSourceOfTruthTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/StreamWithoutSourceOfTruthTest.kt
@@ -35,7 +35,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @FlowPreview
-@ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 @RunWith(Parameterized::class)
 class StreamWithoutSourceOfTruthTest(


### PR DESCRIPTION
The alpha04 release of Store caused the requirement of the @ExperimentalStdlibApi annotation for client code. I looked into it, and the only thing in Store that required the annotation was the Kotlin ArrayDeque used in the BufferImpl class. That class is private in the ChannelManager.kt file, so I opted that file into the annotation and removed all other occurences of the annotation.

Code compiles, all 208 tests pass.
