### PR TITLE
Fix a deadlock during cache eviction

### DIFF
--- a/cache/src/main/kotlin/com/dropbox/android/external/cache4/RealCache.kt
+++ b/cache/src/main/kotlin/com/dropbox/android/external/cache4/RealCache.kt
@@ -301,7 +301,7 @@ internal class RealCache<Key : Any, Value : Any>(
  * A cache entry can be reused by updating [value], [accessTimeNanos], or [writeTimeNanos],
  * as this allows us to avoid creating new instance of [CacheEntry] on every access and write.
  */
-private data class CacheEntry<Key : Any, Value : Any>(
+private class CacheEntry<Key : Any, Value : Any>(
     val key: Key,
     @Volatile var value: Value,
     @Volatile var accessTimeNanos: Long = Long.MAX_VALUE,

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/ConcurrentStoreRequestTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/ConcurrentStoreRequestTest.kt
@@ -1,0 +1,42 @@
+package com.dropbox.android.external.store4.impl
+
+import com.dropbox.android.external.store4.MemoryPolicy
+import com.dropbox.android.external.store4.StoreBuilder
+import com.dropbox.android.external.store4.get
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import kotlin.time.ExperimentalTime
+import kotlin.time.minutes
+
+@FlowPreview
+@ExperimentalTime
+@ExperimentalStdlibApi
+@ExperimentalCoroutinesApi
+@RunWith(JUnit4::class)
+class ConcurrentStoreRequestTest {
+
+    @Test
+    fun `concurrent store requests can complete when loaded data exceeds maximum in-memory cache size`() {
+        val store = StoreBuilder
+            .fromNonFlow { _: Int -> "result" }
+            .cachePolicy(
+                MemoryPolicy
+                    .builder()
+                    .setExpireAfterAccess(10.minutes)
+                    .setMemorySize(1)
+                    .build()
+            )
+            .build()
+
+        runBlocking {
+            store.get(0)
+            store.get(0)
+            store.get(1)
+            store.get(2)
+        }
+    }
+}

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/StoreWithInMemoryCacheTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/StoreWithInMemoryCacheTest.kt
@@ -17,10 +17,10 @@ import kotlin.time.minutes
 @ExperimentalStdlibApi
 @ExperimentalCoroutinesApi
 @RunWith(JUnit4::class)
-class ConcurrentStoreRequestTest {
+class StoreWithInMemoryCacheTest {
 
     @Test
-    fun `concurrent store requests can complete when loaded data exceeds maximum in-memory cache size`() {
+    fun `store requests can complete when its in-memory cache (with access expiry) is at the maximum size`() {
         val store = StoreBuilder
             .fromNonFlow { _: Int -> "result" }
             .cachePolicy(


### PR DESCRIPTION
Fixes #152.

PR fixes a deadlock during cache eviction due to duplicate `CacheEntries` with different `accessTimeNanos` being added to the `accessQueue` HashSet.

`CacheEntry` should not have been a data class.

Added a cache eviction test and a higher level integration test in `store` module.