### PR TITLE
Coroutines 1.3.5

### DIFF
--- a/app/src/main/java/com/dropbox/android/sample/SampleApp.kt
+++ b/app/src/main/java/com/dropbox/android/sample/SampleApp.kt
@@ -5,13 +5,9 @@ import com.dropbox.android.external.store4.Persister
 import com.dropbox.android.external.store4.Store
 import com.dropbox.android.external.store4.legacy.BarCode
 import com.dropbox.android.sample.data.model.Post
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import okio.BufferedSource
 import java.io.IOException
 
-@FlowPreview
-@ExperimentalCoroutinesApi
 class SampleApp : Application() {
     lateinit var roomStore: Store<String, List<Post>>
 
@@ -21,8 +17,6 @@ class SampleApp : Application() {
 
     lateinit var persister: Persister<BufferedSource, BarCode>
 
-    @FlowPreview
-    @ExperimentalCoroutinesApi
     override fun onCreate() {
         super.onCreate()
         initPersister()

--- a/app/src/main/java/com/dropbox/android/sample/ui/room/RoomFragment.kt
+++ b/app/src/main/java/com/dropbox/android/sample/ui/room/RoomFragment.kt
@@ -99,7 +99,6 @@ class RoomFragment : Fragment() {
 /**
  * This class should possibly be moved to a helper library but needs more API work before that.
  */
-@FlowPreview
 @ExperimentalCoroutinesApi
 internal class StoreState<Key : Any, Output : Any>(
     private val store: Store<Key, Output>

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -3,26 +3,26 @@ ext.versions = [
         targetSdk         : 29,
         compileSdk        : 29,
         buildTools        : '29.0.3',
-        kotlin            : '1.3.71',
+        kotlin            : '1.3.72',
         ktlint            : '0.36.0',
 
         // Plugins
-        androidGradlePlugin         : '4.0.0-beta04',
+        androidGradlePlugin         : '4.0.0-beta05',
         dokkaGradlePlugin           : '0.10.0',
         ktlintGradle                : '9.1.1',
         spotlessGradlePlugin        : '3.26.1',
         jacocoGradlePlugin          : '0.8.5',
-        binaryCompatibilityValidator: '0.2.1',
+        binaryCompatibilityValidator: '0.2.3',
         atomicFuPlugin              : '0.14.2',
 
         // UI libs.
         picasso           : '2.5.2',
 
         // Others.
-        coroutines        : '1.3.5',
+        coroutines        : '1.3.6',
         retrofit          : '2.8.1',
-        okHttp            : '4.5.0',
-        okio              : '2.4.3',
+        okHttp            : '4.6.0',
+        okio              : '2.6.0',
         moshi             : '1.9.2',
         appCompat         : '1.1.0',
         fragment          : '1.2.4',
@@ -34,7 +34,7 @@ ext.versions = [
         lifecycle         : '2.2.0',
         navigation        : '2.2.1',
         constraintLayout  : '1.1.3',
-        rx2               : '2.2.18',
+        rx2               : '2.2.19',
 
         // Testing.
         junit             : '4.13',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-all.zip

--- a/multicast/build.gradle
+++ b/multicast/build.gradle
@@ -21,6 +21,9 @@ sourceCompatibility = 1.8
 compileKotlin {
     kotlinOptions {
         jvmTarget = "1.8"
+        freeCompilerArgs += [
+                '-Xopt-in=kotlin.RequiresOptIn',
+        ]
     }
 }
 compileTestKotlin {

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/ChannelManager.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/ChannelManager.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.flow.Flow
  * is no active upstream and there's at least one downstream that has not received a value.
  *
  */
-@ExperimentalCoroutinesApi
 internal class ChannelManager<T>(
     /**
      * The scope in which ChannelManager actor runs
@@ -360,7 +359,6 @@ internal class ChannelManager<T>(
 /**
  * Buffer implementation for any late arrivals.
  */
-@ExperimentalCoroutinesApi
 private interface Buffer<T> {
     fun add(item: ChannelManager.Message.Dispatch.Value<T>)
     fun isEmpty() = items.isEmpty()
@@ -370,7 +368,6 @@ private interface Buffer<T> {
 /**
  * Default implementation of buffer which does not buffer anything.
  */
-@ExperimentalCoroutinesApi
 private class NoBuffer<T> : Buffer<T> {
     override val items: Collection<ChannelManager.Message.Dispatch.Value<T>>
         get() = emptyList()
@@ -383,7 +380,6 @@ private class NoBuffer<T> : Buffer<T> {
  * Create a new buffer insteance based on the provided limit.
  */
 @Suppress("FunctionName")
-@ExperimentalCoroutinesApi
 private fun <T> Buffer(limit: Int): Buffer<T> = if (limit > 0) {
     BufferImpl(limit)
 } else {
@@ -393,7 +389,6 @@ private fun <T> Buffer(limit: Int): Buffer<T> = if (limit > 0) {
 /**
  * A real buffer implementation that has a FIFO queue.
  */
-@ExperimentalCoroutinesApi
 private class BufferImpl<T>(private val limit: Int) :
     Buffer<T> {
     override val items = ArrayDeque<ChannelManager.Message.Dispatch.Value<T>>(limit.coerceAtMost(10))

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/Multicaster.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/Multicaster.kt
@@ -18,7 +18,6 @@ package com.dropbox.flow.multicast
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.flow.Flow
@@ -36,7 +35,6 @@ import kotlinx.coroutines.flow.transform
  * downstream value collects the latest dispatched value OR a new downstream is added while [buffer]
  * is empty.
  */
-@FlowPreview
 @ExperimentalCoroutinesApi
 class Multicaster<T>(
     /**

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/SharedFlowProducer.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/SharedFlowProducer.kt
@@ -18,7 +18,6 @@ package com.dropbox.flow.multicast
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.ClosedSendChannelException
@@ -37,7 +36,6 @@ import kotlinx.coroutines.launch
  * Cancellation of the collection might be triggered by both this producer (e.g. upstream completes)
  * or the [ChannelManager] (e.g. all active collectors complete).
  */
-@ExperimentalCoroutinesApi
 internal class SharedFlowProducer<T>(
     private val scope: CoroutineScope,
     private val src: Flow<T>,

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/StoreRealActor.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/StoreRealActor.kt
@@ -18,7 +18,6 @@ package com.dropbox.flow.multicast
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.actor
@@ -28,7 +27,6 @@ import kotlinx.coroutines.channels.actor
  * It also enforces a 0 capacity buffer.
  */
 @Suppress("EXPERIMENTAL_API_USAGE")
-@ExperimentalCoroutinesApi
 internal abstract class StoreRealActor<T>(
     scope: CoroutineScope
 ) {

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerTest.kt
@@ -17,7 +17,6 @@ package com.dropbox.flow.multicast
 
 import com.dropbox.flow.multicast.ChannelManager.Message.Dispatch
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
@@ -31,12 +30,11 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.test.fail
-import kotlin.test.Test
 
-@FlowPreview
 @ExperimentalCoroutinesApi
 class ChannelManagerTest {
     private val scope = TestCoroutineScope()

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/InfiniteMulticastTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/InfiniteMulticastTest.kt
@@ -16,7 +16,6 @@
 package com.dropbox.flow.multicast
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -36,7 +35,6 @@ import kotlin.test.assertEquals
  * It basically waits until there is another reason to enable upstream and will receive those
  * values as well.
  */
-@FlowPreview
 @ExperimentalCoroutinesApi
 class InfiniteMulticastTest {
     private val testScope = TestCoroutineScope()

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/MulticastTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/MulticastTest.kt
@@ -17,7 +17,6 @@ package com.dropbox.flow.multicast
 
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -40,11 +39,10 @@ import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.yield
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.test.assertFailsWith
 
-@FlowPreview
 @ExperimentalCoroutinesApi
 class MulticastTest {
     private val testScope = TestCoroutineScope()

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/SharedFlowProducerTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/SharedFlowProducerTest.kt
@@ -23,11 +23,11 @@ import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class, ExperimentalStdlibApi::class)
+@ExperimentalCoroutinesApi
 class SharedFlowProducerTest {
     private val scope = TestCoroutineScope()
     private val upstreamMessages = mutableListOf<String>()
-    private fun createProducer(flow: Flow<String>) = SharedFlowProducer<String>(
+    private fun createProducer(flow: Flow<String>) = SharedFlowProducer(
         scope = scope,
         src = flow,
         sendUpsteamMessage = {

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/StoreRealActorTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/StoreRealActorTest.kt
@@ -18,7 +18,6 @@ package com.dropbox.flow.multicast
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -28,7 +27,6 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-@ExperimentalCoroutinesApi
 class StoreRealActorTest {
     private val didClose = atomic<Boolean>(false)
 

--- a/store-rx2/src/main/kotlin/com/dropbox/store/rx2/RxFetcher.kt
+++ b/store-rx2/src/main/kotlin/com/dropbox/store/rx2/RxFetcher.kt
@@ -6,8 +6,6 @@ import com.dropbox.android.external.store4.Store
 import com.dropbox.android.external.store4.valueFetcher
 import io.reactivex.Flowable
 import io.reactivex.Single
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.reactive.asFlow
 
 /**
@@ -21,8 +19,6 @@ import kotlinx.coroutines.reactive.asFlow
  *
  * @param flowableFactory a factory for a [Flowable] source of network records.
  */
-@FlowPreview
-@ExperimentalCoroutinesApi
 fun <Key : Any, Output : Any> flowableFetcher(
     flowableFactory: (key: Key) -> Flowable<FetcherResult<Output>>
 ): Fetcher<Key, Output> = { key: Key -> flowableFactory(key).asFlow() }
@@ -38,8 +34,6 @@ fun <Key : Any, Output : Any> flowableFetcher(
  *
  * @param singleFactory a factory for a [Single] source of network records.
  */
-@FlowPreview
-@ExperimentalCoroutinesApi
 fun <Key : Any, Output : Any> singleFetcher(
     singleFactory: (key: Key) -> Single<FetcherResult<Output>>
 ): Fetcher<Key, Output> = { key: Key -> singleFactory(key).toFlowable().asFlow() }
@@ -56,8 +50,6 @@ fun <Key : Any, Output : Any> singleFetcher(
  *
  * @param flowFactory a factory for a [Flowable] source of network records.
  */
-@FlowPreview
-@ExperimentalCoroutinesApi
 fun <Key : Any, Output : Any> flowableValueFetcher(
     flowableFactory: (key: Key) -> Flowable<Output>
 ): Fetcher<Key, Output> = valueFetcher { key: Key -> flowableFactory(key).asFlow() }
@@ -74,8 +66,6 @@ fun <Key : Any, Output : Any> flowableValueFetcher(
  *
  * @param singleFactory a factory for a [Single] source of network records.
  */
-@FlowPreview
-@ExperimentalCoroutinesApi
 fun <Key : Any, Output : Any> singleValueFetcher(
     singleFactory: (key: Key) -> Single<Output>
 ): Fetcher<Key, Output> = flowableValueFetcher { key: Key -> singleFactory(key).toFlowable() }

--- a/store-rx2/src/main/kotlin/com/dropbox/store/rx2/RxSourceOfTruth.kt
+++ b/store-rx2/src/main/kotlin/com/dropbox/store/rx2/RxSourceOfTruth.kt
@@ -4,8 +4,6 @@ import com.dropbox.android.external.store4.SourceOfTruth
 import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Maybe
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.rx2.await
 
@@ -19,8 +17,6 @@ import kotlinx.coroutines.rx2.await
  * @param deleteAll function for deleting all records in the source of truth
  *
  */
-@FlowPreview
-@ExperimentalCoroutinesApi
 fun <Key : Any, Input : Any, Output : Any> SourceOfTruth.Companion.fromMaybe(
     reader: (Key) -> Maybe<Output>,
     writer: (Key, Input) -> Completable,
@@ -48,8 +44,6 @@ fun <Key : Any, Input : Any, Output : Any> SourceOfTruth.Companion.fromMaybe(
  * @param deleteAll function for deleting all records in the source of truth
  *
  */
-@FlowPreview
-@ExperimentalCoroutinesApi
 fun <Key : Any, Input : Any, Output : Any> SourceOfTruth.Companion.fromFlowable(
     reader: (Key) -> Flowable<Output>,
     writer: (Key, Input) -> Completable,

--- a/store/src/main/java/com/dropbox/android/external/store4/Fetcher.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/Fetcher.kt
@@ -1,6 +1,5 @@
 package com.dropbox.android.external.store4
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
@@ -69,7 +68,6 @@ fun <Key : Any, Output : Any> nonFlowFetcher(
  *
  * @param flowFactory a factory for a [Flow]ing source of network records.
  */
-@ExperimentalCoroutinesApi
 fun <Key : Any, Output : Any> valueFetcher(
     flowFactory: (Key) -> Flow<Output>
 ): Fetcher<Key, Output> = { key: Key ->
@@ -90,7 +88,6 @@ fun <Key : Any, Output : Any> valueFetcher(
  *
  * @param doFetch a source of network records.
  */
-@ExperimentalCoroutinesApi
 fun <Key : Any, Output : Any> nonFlowValueFetcher(
     doFetch: suspend (key: Key) -> Output
 ): Fetcher<Key, Output> = valueFetcher(doFetch.asFlow())

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/operators/MapIndexed.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/operators/MapIndexed.kt
@@ -15,12 +15,10 @@
  */
 package com.dropbox.android.external.store4.impl.operators
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectIndexed
 import kotlinx.coroutines.flow.flow
 
-@ExperimentalCoroutinesApi
 internal inline fun <T, R> Flow<T>.mapIndexed(crossinline block: (Int, T) -> R) = flow {
     this@mapIndexed.collectIndexed { index, value ->
         emit(block(index, value))


### PR DESCRIPTION
Update coroutines to 1.3.5 and clean up `@FlowPreview` and `@ExperimentalCoroutinesApi` which are no longer required.

Also updated kotlin sdtlib, Rx2, OkHttp, Okio and Gradle.