### PR TITLE
fix doc: default policy of max items count

### DIFF
--- a/store/src/main/java/com/dropbox/android/external/store4/StoreBuilder.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/StoreBuilder.kt
@@ -47,7 +47,7 @@ interface StoreBuilder<Key : Any, Output : Any> {
     fun cachePolicy(memoryPolicy: MemoryPolicy?): StoreBuilder<Key, Output>
 
     /**
-     * by default a Store caches in memory with a default policy of max items = 16
+     * by default a Store caches in memory with a default policy of max items = 100
      */
     fun disableCache(): StoreBuilder<Key, Output>
 


### PR DESCRIPTION
I fixed the comment because StoreDefaults.cacheSize is 100.
(Sorry for the very small fix.)