### PR TITLE
Emit source of truth errors to subscribers #177

### DIFF
--- a/store/api/store.api
+++ b/store/api/store.api
@@ -113,6 +113,21 @@ public final class com/dropbox/android/external/store4/SourceOfTruth$Companion {
 	public static synthetic fun ofFlow$default (Lcom/dropbox/android/external/store4/SourceOfTruth$Companion;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/dropbox/android/external/store4/SourceOfTruth;
 }
 
+public final class com/dropbox/android/external/store4/SourceOfTruth$ReadException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Throwable;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/Object;
+	public fun hashCode ()I
+}
+
+public final class com/dropbox/android/external/store4/SourceOfTruth$WriteException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/Object;
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+}
+
 public abstract interface class com/dropbox/android/external/store4/Store {
 	public abstract fun clear (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun clearAll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/store/src/main/java/com/dropbox/android/external/store4/SourceOfTruth.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/SourceOfTruth.kt
@@ -126,4 +126,76 @@ interface SourceOfTruth<Key, Input, Output> {
             realDeleteAll = deleteAll
         )
     }
+
+    /**
+     * The exception provided when a Write operation fails in SourceOfTruth.
+     *
+     * see [StoreResponse.Error.Exception]
+     */
+    class WriteException(
+        /**
+         * The key for the failed write attempt
+         */
+        val key: Any?, // TODO why are we not marking keys non-null ?
+        /**
+         * The value for the failed write attempt
+         */
+        val value:Any?,
+        /**
+         * The exception thrown from the [SourceOfTruth]'s [write] method.
+         */
+        cause : Throwable
+    ) : RuntimeException(
+        "Failed to write value to Source of Truth. key: $key",
+        cause
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as WriteException
+
+            if (key != other.key) return false
+            if (value != other.value) return false
+            if (cause != other.cause) return false
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = key.hashCode()
+            result = 31 * result + value.hashCode()
+            return result
+        }
+    }
+
+    /**
+     * Exception created when a [reader] throws an exception.
+     *
+     * see [StoreResponse.Error.Exception]
+     */
+    class ReadException(
+        /**
+         * The key for the failed write attempt
+         */
+        val key: Any?, // TODO shouldn't key be non-null?
+        cause: Throwable
+    ) : RuntimeException(
+        "Failed to read from Source of Truth. key: $key",
+        cause
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as ReadException
+
+            if (key != other.key) return false
+            if (cause != other.cause) return false
+            return true
+        }
+
+        override fun hashCode(): Int {
+            return key.hashCode()
+        }
+    }
 }

--- a/store/src/main/java/com/dropbox/android/external/store4/SourceOfTruth.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/SourceOfTruth.kt
@@ -140,11 +140,11 @@ interface SourceOfTruth<Key, Input, Output> {
         /**
          * The value for the failed write attempt
          */
-        val value:Any?,
+        val value: Any?,
         /**
          * The exception thrown from the [SourceOfTruth]'s [write] method.
          */
-        cause : Throwable
+        cause: Throwable
     ) : RuntimeException(
         "Failed to write value to Source of Truth. key: $key",
         cause

--- a/store/src/main/java/com/dropbox/android/external/store4/SourceOfTruth.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/SourceOfTruth.kt
@@ -128,7 +128,7 @@ interface SourceOfTruth<Key, Input, Output> {
     }
 
     /**
-     * The exception provided when a Write operation fails in SourceOfTruth.
+     * The exception provided when a write operation fails in SourceOfTruth.
      *
      * see [StoreResponse.Error.Exception]
      */

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
@@ -189,10 +189,11 @@ internal class RealStore<Key : Any, Input : Any, Output : Any>(
                 } else if (it is Either.Right) {
                     // right, that is data from disk
                     val (index, diskData) = it.value
-                    if (diskData.value != null) {
+                    val diskValue = diskData.dataOrNull()
+                    if (diskValue != null) {
                         emit(
                             StoreResponse.Data(
-                                value = diskData.value,
+                                value = diskValue,
                                 origin = diskData.origin
                             )
                         )
@@ -200,7 +201,7 @@ internal class RealStore<Key : Any, Input : Any, Output : Any>(
 
                     // if this is the first disk value and it is null, we should enable fetcher
                     // TODO should we ignore the index and always enable?
-                    if (index == 0 && (diskData.value == null || request.refresh)) {
+                    if (index == 0 && (diskValue == null || request.refresh)) {
                         networkLock.complete(Unit)
                     }
                 }

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
@@ -210,7 +210,7 @@ internal class RealStore<Key : Any, Input : Any, Output : Any>(
                             networkLock.complete(Unit)
                         }
                         // for other errors, don't do anything, wait for the read attempt
-                    } else if (diskData is StoreResponse.Data){
+                    } else if (diskData is StoreResponse.Data) {
                         if (request.refresh || diskValue == null) {
                             networkLock.complete(Unit)
                         }

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
@@ -188,7 +188,7 @@ internal class RealStore<Key : Any, Input : Any, Output : Any>(
                     }
                 } else if (it is Either.Right) {
                     // right, that is data from disk
-                    val (index, diskData) = it.value
+                    val (_, diskData) = it.value
                     val diskValue = diskData.dataOrNull()
                     if (diskValue != null) {
                         emit(

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
@@ -202,9 +202,12 @@ internal class RealStore<Key : Any, Input : Any, Output : Any>(
                         emit(diskData.swapType())
                     }
 
-                    // if this is the first disk value and it is null, we should enable fetcher
-                    // we should also allow fetcher if disk sent a read error but not if it is
-                    // a write error since we should always wait for the read attempt
+                    // If this is the first disk value and it is null, we should allow fetcher
+                    // to start emitting values.
+                    // If disk sent a read error, we should allow fetcher to start emitting values
+                    // since there is nothing to read from disk.
+                    // If disk sent a write error, we should NOT allow fetcher to start emitting
+                    // values as we should always wait for the read attempt.
                     if (diskData is StoreResponse.Error.Exception) {
                         if (diskData.error is SourceOfTruth.ReadException) {
                             networkLock.complete(Unit)

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/SourceOfTruthWithBarrier.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/SourceOfTruthWithBarrier.kt
@@ -19,6 +19,7 @@ import com.dropbox.android.external.store4.ResponseOrigin
 import com.dropbox.android.external.store4.SourceOfTruth
 import com.dropbox.android.external.store4.StoreResponse
 import com.dropbox.android.external.store4.impl.operators.mapIndexed
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -30,6 +31,7 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.onStart
 import java.util.concurrent.atomic.AtomicLong
 
 /**
@@ -67,28 +69,58 @@ internal class SourceOfTruthWithBarrier<Key, Input, Output>(
                 emitAll(barrier.asFlow()
                     .flatMapLatest {
                         val messageArrivedAfterMe = readerVersion < it.version
-                        when (it) {
+                        val writeError = if (messageArrivedAfterMe && it is BarrierMsg.Open) {
+                            it.writeError
+                        } else {
+                            null
+                        }
+                        val readFlow = when (it) {
                             is BarrierMsg.Open -> delegate.reader(key).mapIndexed { index, output ->
                                 if (index == 0 && messageArrivedAfterMe) {
+                                    val firstMsgOrigin = if (writeError == null) {
+                                        // restarted barrier without an error means write succeeded
+                                        ResponseOrigin.Fetcher
+                                    } else {
+                                        // when a write fails, we still get a new reader because
+                                        // we've disabled the previous reader before starting the
+                                        // write operation. But since write has failed, we should
+                                        // use the SourceOfTruth as the origin
+                                        ResponseOrigin.SourceOfTruth
+                                    }
                                     StoreResponse.Data(
-                                        origin = ResponseOrigin.Fetcher,
+                                        origin = firstMsgOrigin,
                                         value = output
                                     )
                                 } else {
                                     StoreResponse.Data(
                                         origin = ResponseOrigin.SourceOfTruth,
                                         value = output
-                                    ) as StoreResponse<Output?>
-                                }
+                                    )
+                                } as StoreResponse<Output?> // necessary cast for catch block
                             }.catch {
                                 this.emit(StoreResponse.Error.Exception<Output>(
-                                    error = it,
+                                    error = SourceOfTruth.ReadException(
+                                        key = key,
+                                        cause = it
+                                    ),
                                     origin = ResponseOrigin.SourceOfTruth))
                             }
                             is BarrierMsg.Blocked -> {
                                 flowOf()
                             }
                         }
+                        readFlow
+                            .onStart {
+                                // if we have a pending error, make sure to dispatch it first.
+                                if (writeError != null) {
+                                    emit(
+                                        StoreResponse.Error.Exception(
+                                            origin = ResponseOrigin.SourceOfTruth,
+                                            error = writeError
+                                        )
+                                    )
+                                }
+                            }
                     })
             } finally {
                 // we are using a finally here instead of onCompletion as there might be a
@@ -102,8 +134,31 @@ internal class SourceOfTruthWithBarrier<Key, Input, Output>(
         val barrier = barriers.acquire(key)
         try {
             barrier.send(BarrierMsg.Blocked(versionCounter.incrementAndGet()))
-            delegate.write(key, value)
-            barrier.send(BarrierMsg.Open(versionCounter.incrementAndGet()))
+            val writeError = try {
+                delegate.write(key, value)
+                null
+            } catch (throwable : Throwable) {
+                if (throwable !is CancellationException) {
+                    throwable
+                } else {
+                    null
+                }
+            }
+
+            barrier.send(BarrierMsg.Open(
+                version = versionCounter.incrementAndGet(),
+                writeError = writeError?.let {
+                    SourceOfTruth.WriteException(
+                        key = key,
+                        value = value,
+                        cause = writeError
+                    )
+                }))
+            if (writeError is CancellationException) {
+                // only throw if it failed because of cancelation.
+                // otherwise, we take care of letting downstream know that there was a write error
+                throw writeError
+            }
         } finally {
             barriers.release(key, barrier)
         }
@@ -121,7 +176,7 @@ internal class SourceOfTruthWithBarrier<Key, Input, Output>(
         val version: Long
     ) {
         class Blocked(version: Long) : BarrierMsg(version)
-        class Open(version: Long) : BarrierMsg(version) {
+        class Open(version: Long, val writeError: Throwable? = null) : BarrierMsg(version) {
             companion object {
                 val INITIAL = Open(INITIAL_VERSION)
             }

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/SourceOfTruthWithBarrier.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/SourceOfTruthWithBarrier.kt
@@ -137,7 +137,7 @@ internal class SourceOfTruthWithBarrier<Key, Input, Output>(
             val writeError = try {
                 delegate.write(key, value)
                 null
-            } catch (throwable : Throwable) {
+            } catch (throwable: Throwable) {
                 if (throwable !is CancellationException) {
                     throwable
                 } else {
@@ -145,15 +145,17 @@ internal class SourceOfTruthWithBarrier<Key, Input, Output>(
                 }
             }
 
-            barrier.send(BarrierMsg.Open(
-                version = versionCounter.incrementAndGet(),
-                writeError = writeError?.let {
-                    SourceOfTruth.WriteException(
-                        key = key,
-                        value = value,
-                        cause = writeError
-                    )
-                }))
+            barrier.send(
+                BarrierMsg.Open(
+                    version = versionCounter.incrementAndGet(),
+                    writeError = writeError?.let {
+                        SourceOfTruth.WriteException(
+                            key = key,
+                            value = value,
+                            cause = writeError
+                        )
+                    })
+            )
             if (writeError is CancellationException) {
                 // only throw if it failed because of cancelation.
                 // otherwise, we take care of letting downstream know that there was a write error

--- a/store/src/test/java/com/dropbox/android/external/store4/SourceOfTruthErrorsTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/SourceOfTruthErrorsTest.kt
@@ -183,7 +183,7 @@ class SourceOfTruthErrorsTest {
     fun `GIVEN Source of Truth with failing write WHEN a passive reader arrives THEN it should receive the new write error`() =
         testScope.runBlockingTest {
             val persister = InMemoryPersister<Int, String>()
-            val fetcher = Fetcher.ofFlow { _: Int->
+            val fetcher = Fetcher.ofFlow { _: Int ->
                 flowOf("a", "b", "c", "d")
             }
             val pipeline = StoreBuilder
@@ -348,7 +348,7 @@ class SourceOfTruthErrorsTest {
     fun `Given Source of Truth with read failure WHEN cached value reader arrives THEN fetcher should be called to get a new value`() {
         testScope.runBlockingTest {
             val persister = InMemoryPersister<Int, String>()
-            val fetcher = Fetcher.of { _:Int -> "a" }
+            val fetcher = Fetcher.of { _: Int -> "a" }
             val pipeline = StoreBuilder
                 .from(
                     fetcher = fetcher,

--- a/store/src/test/java/com/dropbox/android/external/store4/SourceOfTruthErrorsTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/SourceOfTruthErrorsTest.kt
@@ -15,11 +15,19 @@
  */
 package com.dropbox.android.external.store4
 
+import com.dropbox.android.external.store4.SourceOfTruth.ReadException
+import com.dropbox.android.external.store4.SourceOfTruth.WriteException
 import com.dropbox.android.external.store4.testutil.FakeFetcher
 import com.dropbox.android.external.store4.testutil.InMemoryPersister
 import com.dropbox.android.external.store4.testutil.asSourceOfTruth
 import com.dropbox.android.external.store4.testutil.assertThat
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
@@ -32,37 +40,359 @@ class SourceOfTruthErrorsTest {
     private val testScope = TestCoroutineScope()
 
     @Test
-    fun writeErrorCanBeCaught() = testScope.runBlockingTest {
-        val persister = ThrowingPersister<Int, String>()
-        val fetcher = FakeFetcher(
-            3 to "three-1",
-            3 to "three-2"
-        )
-        val pipeline = StoreBuilder
-            .from(
-                fetcher = fetcher,
-                sourceOfTruth = persister.asSourceOfTruth())
-            .scope(testScope)
-            .build()
-        val writeException = IllegalArgumentException("i fail")
-        persister.writeHandler = { key, value ->
-            throw writeException
-        }
-        assertThat(
-            pipeline.stream(StoreRequest.fresh(3))
-        ).emitsExactly(
-            StoreResponse.Loading(ResponseOrigin.Fetcher),
-            StoreResponse.Error.Exception(
-                error = writeException,
-                origin = ResponseOrigin.SourceOfTruth
+    fun `GIVEN Source of Truth WHEN write fails THEN exception should be send to the collector`() =
+        testScope.runBlockingTest {
+            val persister = InMemoryPersister<Int, String>()
+            val fetcher = FakeFetcher(
+                3 to "a",
+                3 to "b"
             )
-        )
+            val pipeline = StoreBuilder
+                .from(
+                    fetcher = fetcher,
+                    sourceOfTruth = persister.asSourceOfTruth()
+                )
+                .scope(testScope)
+                .build()
+            persister.preWriteCallback = { _, _ ->
+                throw TestException("i fail")
+            }
+
+            assertThat(
+                pipeline.stream(StoreRequest.fresh(3))
+            ).emitsExactly(
+                StoreResponse.Loading(ResponseOrigin.Fetcher),
+                StoreResponse.Error.Exception(
+                    error = WriteException(
+                        key = 3,
+                        value = "a",
+                        cause = TestException("i fail")
+                    ),
+                    origin = ResponseOrigin.SourceOfTruth
+                )
+            )
+        }
+
+    @Test
+    fun `GIVEN Source of Truth WHEN read fails THEN exception should be send to the collector`() =
+        testScope.runBlockingTest {
+            val persister = InMemoryPersister<Int, String>()
+            val fetcher = FakeFetcher(
+                3 to "a",
+                3 to "b"
+            )
+            val pipeline = StoreBuilder
+                .from(
+                    fetcher = fetcher,
+                    sourceOfTruth = persister.asSourceOfTruth()
+                )
+                .scope(testScope)
+                .build()
+
+            persister.postReadCallback = { _, value ->
+                throw TestException(value ?: "null")
+            }
+
+            assertThat(
+                pipeline.stream(StoreRequest.cached(3, refresh = false))
+            ).emitsExactly(
+                StoreResponse.Error.Exception(
+                    error = ReadException(
+                        key = 3,
+                        cause = TestException("a")
+                    ),
+                    origin = ResponseOrigin.SourceOfTruth
+                ),
+                // after disk fails, we should still invoke fetcher
+                StoreResponse.Loading(
+                    origin = ResponseOrigin.Fetcher
+                ),
+                // and after fetcher writes the value, it will trigger another read which will also
+                // fail
+                StoreResponse.Error.Exception(
+                    error = ReadException(
+                        key = 3,
+                        cause = TestException("b")
+                    ),
+                    origin = ResponseOrigin.SourceOfTruth
+                )
+            )
+        }
+
+    @Test
+    fun `GIVEN Source of Truth WHEN first write fails THEN it should keep reading from Fetcher`() =
+        testScope.runBlockingTest {
+            val persister = InMemoryPersister<Int, String>()
+            val fetcher = Fetcher.ofFlow { _: Int ->
+                flowOf("a", "b", "c", "d")
+            }
+            val pipeline = StoreBuilder
+                .from(
+                    fetcher = fetcher,
+                    sourceOfTruth = persister.asSourceOfTruth()
+                )
+                .disableCache()
+                .scope(testScope)
+                .build()
+            persister.preWriteCallback = { _, value ->
+                if (value in listOf("a", "c")) {
+                    throw TestException(value)
+                }
+                value
+            }
+            assertThat(
+                pipeline.stream(StoreRequest.cached(3, refresh = true))
+            ).emitsExactly(
+                StoreResponse.Loading(
+                    origin = ResponseOrigin.Fetcher
+                ),
+                StoreResponse.Error.Exception(
+                    error = WriteException(
+                        key = 3,
+                        value = "a",
+                        cause = TestException("a")
+                    ),
+                    origin = ResponseOrigin.SourceOfTruth
+                ),
+                StoreResponse.Data(
+                    value = "b",
+                    origin = ResponseOrigin.Fetcher
+                ),
+                StoreResponse.Error.Exception(
+                    error = WriteException(
+                        key = 3,
+                        value = "c",
+                        cause = TestException("c")
+                    ),
+                    origin = ResponseOrigin.SourceOfTruth
+                ),
+                // disk flow will restart after a failed write (because we stopped it before the
+                // write attempt starts, so we will get the disk value again).
+                StoreResponse.Data(
+                    value = "b",
+                    origin = ResponseOrigin.SourceOfTruth
+                ),
+                StoreResponse.Data(
+                    value = "d",
+                    origin = ResponseOrigin.Fetcher
+                )
+            )
+        }
+
+    @Test
+    fun `GIVEN Source of Truth with failing write WHEN a passive reader arrives THEN it should receive the new write error`() =
+        testScope.runBlockingTest {
+            val persister = InMemoryPersister<Int, String>()
+            val fetcher = Fetcher.ofFlow { _: Int->
+                flowOf("a", "b", "c", "d")
+            }
+            val pipeline = StoreBuilder
+                .from(
+                    fetcher = fetcher,
+                    sourceOfTruth = persister.asSourceOfTruth()
+                )
+                .disableCache()
+                .scope(testScope)
+                .build()
+            persister.preWriteCallback = { _, value ->
+                if (value in listOf("a", "c")) {
+                    delay(50)
+                    throw TestException(value)
+                } else {
+                    delay(10)
+                }
+                value
+            }
+            // keep collection hot
+            val collector = launch {
+                pipeline.stream(
+                    StoreRequest.cached(3, refresh = true)
+                ).toList()
+            }
+
+            // miss writes for a and b and let the write operation for c start such that
+            // we'll catch that write error
+            delay(70)
+            assertThat(
+                pipeline.stream(StoreRequest.cached(3, refresh = true))
+            ).emitsExactly(
+                // we wanted the disk value but write failed so we don't get it
+                StoreResponse.Error.Exception(
+                    error = WriteException(
+                        key = 3,
+                        value = "c",
+                        cause = TestException("c")
+                    ),
+                    origin = ResponseOrigin.SourceOfTruth
+                ),
+                // after the write error, we should get the value on disk
+                StoreResponse.Data(
+                    value = "b",
+                    origin = ResponseOrigin.SourceOfTruth
+                ),
+                // now we'll unlock the fetcher after disk is read
+                StoreResponse.Loading(
+                    origin = ResponseOrigin.Fetcher
+                ),
+                StoreResponse.Data(
+                    value = "d",
+                    origin = ResponseOrigin.Fetcher
+                )
+            )
+            collector.cancelAndJoin()
+        }
+
+    @Test
+    fun `Given Source of Truth with failing write WHEN a passive reader arrives THEN it should not get errors happened before`() =
+        testScope.runBlockingTest {
+            val persister = InMemoryPersister<Int, String>()
+            val fetcher = Fetcher.ofFlow<Int, String> {
+                flow {
+                    emit("a")
+                    emit("b")
+                    emit("c")
+                    // now delay, wait for the new subscriber
+                    delay(100)
+                    emit("d")
+                }
+            }
+            val pipeline = StoreBuilder
+                .from(
+                    fetcher = fetcher,
+                    sourceOfTruth = persister.asSourceOfTruth()
+                )
+                .disableCache()
+                .scope(testScope)
+                .build()
+            persister.preWriteCallback = { _, value ->
+                if (value in listOf("a", "c")) {
+                    throw TestException(value)
+                }
+                value
+            }
+            val collector = launch {
+                pipeline.stream(
+                    StoreRequest.cached(3, refresh = true)
+                ).toList() // keep collection hot
+            }
+
+            // miss both failures but arrive before d is fetched
+            delay(70)
+            assertThat(
+                pipeline.stream(StoreRequest.skipMemory(3, refresh = true))
+            ).emitsExactly(
+                StoreResponse.Data(
+                    value = "b",
+                    origin = ResponseOrigin.SourceOfTruth
+                ),
+                // don't receive the write exception because technically it started before we
+                // started reading
+                StoreResponse.Loading(
+                    origin = ResponseOrigin.Fetcher
+                ),
+                StoreResponse.Data(
+                    value = "d",
+                    origin = ResponseOrigin.Fetcher
+                )
+            )
+            collector.cancelAndJoin()
+        }
+
+    @Test
+    fun `Given Source of Truth with failing write WHEN a fresh value reader arrives THEN it should not get disk errors from a pending write`() =
+        testScope.runBlockingTest {
+            val persister = InMemoryPersister<Int, String>()
+            val fetcher = Fetcher.ofFlow<Int, String> {
+                flowOf("a", "b", "c", "d")
+            }
+            val pipeline = StoreBuilder
+                .from(
+                    fetcher = fetcher,
+                    sourceOfTruth = persister.asSourceOfTruth()
+                )
+                .disableCache()
+                .scope(testScope)
+                .build()
+            persister.preWriteCallback = { _, value ->
+                if (value == "c") {
+                    // slow down read so that the new reader arrives
+                    delay(50)
+                }
+                if (value in listOf("a", "c")) {
+                    throw TestException(value)
+                }
+                value
+            }
+            val collector = launch {
+                pipeline.stream(
+                    StoreRequest.cached(3, refresh = true)
+                ).toList() // keep collection hot
+            }
+            // miss both failures but arrive before d is fetched
+            delay(20)
+            assertThat(
+                pipeline.stream(StoreRequest.fresh(3))
+            ).emitsExactly(
+                StoreResponse.Loading(
+                    origin = ResponseOrigin.Fetcher
+                ),
+                StoreResponse.Data(
+                    value = "d",
+                    origin = ResponseOrigin.Fetcher
+                )
+            )
+            collector.cancelAndJoin()
+        }
+
+    @Test
+    fun `Given Source of Truth with read failure WHEN cached value reader arrives THEN fetcher should be called to get a new value`() {
+        testScope.runBlockingTest {
+            val persister = InMemoryPersister<Int, String>()
+            val fetcher = Fetcher.of { _:Int -> "a" }
+            val pipeline = StoreBuilder
+                .from(
+                    fetcher = fetcher,
+                    sourceOfTruth = persister.asSourceOfTruth()
+                )
+                .disableCache()
+                .scope(testScope)
+                .build()
+            persister.postReadCallback = { _, value ->
+                if (value == null) {
+                    throw TestException("first read")
+                }
+                value
+            }
+            assertThat(
+                pipeline.stream(StoreRequest.cached(3, refresh = true))
+            ).emitsExactly(
+                StoreResponse.Error.Exception(
+                    origin = ResponseOrigin.SourceOfTruth,
+                    error = ReadException(
+                        key = 3,
+                        cause = TestException("first read")
+                    )
+                ),
+                StoreResponse.Loading(
+                    origin = ResponseOrigin.Fetcher
+                ),
+                StoreResponse.Data(
+                    value = "a",
+                    origin = ResponseOrigin.Fetcher
+                )
+            )
+        }
     }
 
-    class ThrowingPersister<Key:Any, Output:Any> : InMemoryPersister<Key, Output>() {
-        var writeHandler : ((Key, Output) -> Unit)?=null
-        override suspend fun write(key: Key, output: Output) {
-            writeHandler?.invoke(key, output) ?: super.write(key, output)
+    private class TestException(val msg: String) : Exception(msg) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is TestException) return false
+            return msg == other.msg
+        }
+
+        override fun hashCode(): Int {
+            return msg.hashCode()
         }
     }
 }

--- a/store/src/test/java/com/dropbox/android/external/store4/SourceOfTruthErrorsTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/SourceOfTruthErrorsTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dropbox.android.external.store4
+
+import com.dropbox.android.external.store4.testutil.FakeFetcher
+import com.dropbox.android.external.store4.testutil.InMemoryPersister
+import com.dropbox.android.external.store4.testutil.asSourceOfTruth
+import com.dropbox.android.external.store4.testutil.assertThat
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@FlowPreview
+@RunWith(JUnit4::class)
+class SourceOfTruthErrorsTest {
+    private val testScope = TestCoroutineScope()
+
+    @Test
+    fun writeErrorCanBeCaught() = testScope.runBlockingTest {
+        val persister = ThrowingPersister<Int, String>()
+        val fetcher = FakeFetcher(
+            3 to "three-1",
+            3 to "three-2"
+        )
+        val pipeline = StoreBuilder
+            .from(
+                fetcher = fetcher,
+                sourceOfTruth = persister.asSourceOfTruth())
+            .scope(testScope)
+            .build()
+        val writeException = IllegalArgumentException("i fail")
+        persister.writeHandler = { key, value ->
+            throw writeException
+        }
+        assertThat(
+            pipeline.stream(StoreRequest.fresh(3))
+        ).emitsExactly(
+            StoreResponse.Loading(ResponseOrigin.Fetcher),
+            StoreResponse.Error.Exception(
+                error = writeException,
+                origin = ResponseOrigin.SourceOfTruth
+            )
+        )
+    }
+
+    class ThrowingPersister<Key:Any, Output:Any> : InMemoryPersister<Key, Output>() {
+        var writeHandler : ((Key, Output) -> Unit)?=null
+        override suspend fun write(key: Key, output: Output) {
+            writeHandler?.invoke(key, output) ?: super.write(key, output)
+        }
+    }
+}

--- a/store/src/test/java/com/dropbox/android/external/store4/SourceOfTruthErrorsTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/SourceOfTruthErrorsTest.kt
@@ -99,7 +99,7 @@ class SourceOfTruthErrorsTest {
                 StoreResponse.Error.Exception(
                     error = ReadException(
                         key = 3,
-                        cause = TestException("a")
+                        cause = TestException("null")
                     ),
                     origin = ResponseOrigin.SourceOfTruth
                 ),
@@ -112,7 +112,7 @@ class SourceOfTruthErrorsTest {
                 StoreResponse.Error.Exception(
                     error = ReadException(
                         key = 3,
-                        cause = TestException("b")
+                        cause = TestException("a")
                     ),
                     origin = ResponseOrigin.SourceOfTruth
                 )

--- a/store/src/test/java/com/dropbox/android/external/store4/SourceOfTruthWithBarrierTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/SourceOfTruthWithBarrierTest.kt
@@ -29,15 +29,11 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
-import kotlinx.coroutines.yield
 import org.junit.Test
-
 
 @FlowPreview
 @ExperimentalCoroutinesApi

--- a/store/src/test/java/com/dropbox/android/external/store4/testutil/InMemoryPersister.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/testutil/InMemoryPersister.kt
@@ -5,15 +5,24 @@ import com.dropbox.android.external.store4.SourceOfTruth
 /**
  * An in-memory non-flowing persister for testing.
  */
-class InMemoryPersister<Key : Any, Output : Any> {
+open class InMemoryPersister<Key : Any, Output : Any> {
     private val data = mutableMapOf<Key, Output>()
+    var preWriteCallback : (suspend (key:Key, value : Output) -> Output)? = null
+    var postReadCallback : (suspend (key : Key, value : Output?) -> Output?)? = null
 
     @Suppress("RedundantSuspendModifier") // for function reference
-    suspend fun read(key: Key) = data[key]
+    suspend fun read(key: Key) :Output? {
+        val value = data[key]
+        postReadCallback?.let {
+            return it(key, value)
+        }
+        return value
+    }
 
     @Suppress("RedundantSuspendModifier") // for function reference
-    suspend fun write(key: Key, output: Output) {
-        data[key] = output
+    open suspend fun write(key: Key, output: Output) {
+        val value = preWriteCallback?.invoke(key, output) ?: output
+        data[key] = value
     }
 
     @Suppress("RedundantSuspendModifier") // for function reference

--- a/store/src/test/java/com/dropbox/android/external/store4/testutil/InMemoryPersister.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/testutil/InMemoryPersister.kt
@@ -7,11 +7,11 @@ import com.dropbox.android.external.store4.SourceOfTruth
  */
 open class InMemoryPersister<Key : Any, Output : Any> {
     private val data = mutableMapOf<Key, Output>()
-    var preWriteCallback : (suspend (key:Key, value : Output) -> Output)? = null
-    var postReadCallback : (suspend (key : Key, value : Output?) -> Output?)? = null
+    var preWriteCallback: (suspend (key: Key, value: Output) -> Output)? = null
+    var postReadCallback: (suspend (key: Key, value: Output?) -> Output?)? = null
 
     @Suppress("RedundantSuspendModifier") // for function reference
-    suspend fun read(key: Key) :Output? {
+    suspend fun read(key: Key): Output? {
         val value = data[key]
         postReadCallback?.let {
             return it(key, value)


### PR DESCRIPTION
This PR fixes an issue where if SourceOfTruth's read or write method fails, we would just crash.

Now SourceOfTruth has two new exception types, WriteException and ReadException where each exception is sent to downstream as a `StoreResponse.Error.Exception` and stream is kept alive.

If a write fails, reader is simply restarted (because it was previously stopped to prepare for the write).

If a read fails, reader is not restarted until another write attempt happens. This is don't to avoid creating an infinite loop of trying to read from disk.