### PR TITLE
Update to Kotlin 1.4.0, Coroutines 1.3.9 and revert to using Duration.INFINITE

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,7 +69,6 @@ dependencies {
     implementation project(':store')
     implementation project(':cache')
     implementation project(':filesystem')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$versions.kotlin"
 
     implementation libraries.coroutinesCore
     implementation libraries.coroutinesAndroid

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -19,7 +19,7 @@ ext.versions = [
         picasso           : '2.5.2',
 
         // Others.
-        coroutines        : '1.3.8-1.4.0-rc',
+        coroutines        : '1.3.9',
         retrofit          : '2.8.1',
         okHttp            : '4.6.0',
         okio              : '2.6.0',

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -3,7 +3,7 @@ ext.versions = [
         targetSdk         : 29,
         compileSdk        : 29,
         buildTools        : '29.0.3',
-        kotlin            : '1.4.0-rc',
+        kotlin            : '1.4.0',
         ktlint            : '0.36.0',
 
         // Plugins
@@ -66,7 +66,6 @@ ext.libraries = [
         okio                  : "com.squareup.okio:okio:$versions.okio",
         moshi                 : "com.squareup.moshi:moshi:$versions.moshi",
         moshiCodegen          : "com.squareup.moshi:moshi-kotlin-codegen:$versions.moshi",
-        kotlinStdLib          : "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin",
         roomCompiler          : "androidx.room:room-compiler:$versions.room",
         roomRuntime           : "androidx.room:room-ktx:$versions.room",
         coreKtx               : "androidx.core:core-ktx:$versions.coreKtx",

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -3,7 +3,7 @@ ext.versions = [
         targetSdk         : 29,
         compileSdk        : 29,
         buildTools        : '29.0.3',
-        kotlin            : '1.3.72',
+        kotlin            : '1.4.0-rc',
         ktlint            : '0.36.0',
 
         // Plugins
@@ -19,7 +19,7 @@ ext.versions = [
         picasso           : '2.5.2',
 
         // Others.
-        coroutines        : '1.3.6',
+        coroutines        : '1.3.8-1.4.0-rc',
         retrofit          : '2.8.1',
         okHttp            : '4.6.0',
         okio              : '2.6.0',

--- a/cache/build.gradle
+++ b/cache/build.gradle
@@ -12,8 +12,6 @@ plugins {
 }
 
 dependencies {
-    implementation libraries.kotlinStdLib
-
     testImplementation libraries.junit
     testImplementation libraries.truth
     testImplementation libraries.coroutinesTest

--- a/cache/src/main/kotlin/com/dropbox/android/external/cache4/Cache.kt
+++ b/cache/src/main/kotlin/com/dropbox/android/external/cache4/Cache.kt
@@ -1,9 +1,7 @@
 package com.dropbox.android.external.cache4
 
-import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
-import kotlin.time.toDuration
 
 /**
  * An in-memory key-value store with support for time-based (expiration) and size-based evictions.
@@ -125,13 +123,10 @@ interface Cache<in Key : Any, Value : Any> {
  */
 internal class CacheBuilderImpl : Cache.Builder {
 
-    // Ideally these would be set to Duration.INFINITE, but this breaks consumers compiling with
-    // Kotlin 1.4-M3 (not sure why).
-    // TODO: revert back to using Duration.INFINITE once Store is compiled with Kotlin 1.4
     @ExperimentalTime
-    private var expireAfterWriteDuration = Double.POSITIVE_INFINITY.toDuration(TimeUnit.SECONDS)
+    private var expireAfterWriteDuration = Duration.INFINITE
     @ExperimentalTime
-    private var expireAfterAccessDuration = Double.POSITIVE_INFINITY.toDuration(TimeUnit.SECONDS)
+    private var expireAfterAccessDuration = Duration.INFINITE
     private var maxSize = UNSET_LONG
     private var concurrencyLevel = DEFAULT_CONCURRENCY_LEVEL
     private var clock: Clock? = null

--- a/filesystem/build.gradle
+++ b/filesystem/build.gradle
@@ -13,7 +13,6 @@ group = GROUP
 version = VERSION_NAME
 
 dependencies {
-    implementation libraries.kotlinStdLib
     implementation libraries.okio
     implementation libraries.coroutinesCore
     implementation project(path: ':cache')

--- a/multicast/build.gradle
+++ b/multicast/build.gradle
@@ -5,7 +5,6 @@ plugins {
 }
 
 dependencies {
-    implementation libraries.kotlinStdLib
     implementation libraries.coroutinesCore
     testImplementation libraries.coroutinesTest
     testImplementation libraries.kotlinTest

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/Multicaster.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/Multicaster.kt
@@ -106,7 +106,7 @@ class Multicaster<T>(
                         channel.close()
                     }
                 }
-                .transform {
+                .transform<ChannelManager.Message.Dispatch.Value<T>, T> {
                     emit(it.value)
                     it.delivered.complete(Unit)
                 }.onCompletion {

--- a/store-rx2/build.gradle
+++ b/store-rx2/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 dependencies {
-    implementation libraries.kotlinStdLib
     implementation libraries.coroutinesCore
     implementation libraries.coroutinesRx2
     implementation libraries.coroutinesReactive

--- a/store-rx3/build.gradle
+++ b/store-rx3/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 dependencies {
-    implementation libraries.kotlinStdLib
     implementation libraries.coroutinesCore
     implementation libraries.coroutinesRx3
     implementation libraries.coroutinesReactive

--- a/store/api/store.api
+++ b/store/api/store.api
@@ -63,8 +63,8 @@ public final class com/dropbox/android/external/store4/FetcherResult$Error$Messa
 public final class com/dropbox/android/external/store4/MemoryPolicy {
 	public static final field Companion Lcom/dropbox/android/external/store4/MemoryPolicy$Companion;
 	public static final field DEFAULT_SIZE_POLICY J
-	public final fun getExpireAfterAccess ()D
-	public final fun getExpireAfterWrite ()D
+	public final fun getExpireAfterAccess-UwyO8pc ()D
+	public final fun getExpireAfterWrite-UwyO8pc ()D
 	public final fun getHasAccessPolicy ()Z
 	public final fun getHasMaxSize ()Z
 	public final fun getHasWritePolicy ()Z
@@ -74,7 +74,7 @@ public final class com/dropbox/android/external/store4/MemoryPolicy {
 
 public final class com/dropbox/android/external/store4/MemoryPolicy$Companion {
 	public final fun builder ()Lcom/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder;
-	public final fun getDEFAULT_DURATION_POLICY ()D
+	public final fun getDEFAULT_DURATION_POLICY-UwyO8pc ()D
 }
 
 public final class com/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder {

--- a/store/build.gradle
+++ b/store/build.gradle
@@ -17,7 +17,6 @@ group = GROUP
 version = VERSION_NAME
 
 dependencies {
-    implementation libraries.kotlinStdLib
     implementation project(path: ':cache')
     implementation project(path: ':multicast')
     implementation libraries.coroutinesCore

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
@@ -197,7 +197,7 @@ internal class RealStore<Key : Any, Input : Any, Output : Any>(
         }
         // we use a merge implementation that gives the source of the flow so that we can decide
         // based on that.
-        return networkFlow.merge(diskFlow).transform {
+        return networkFlow.merge(diskFlow).transform<Either<StoreResponse<Input>, StoreResponse<Output?>>, StoreResponse<Output>> {
                 // left is Fetcher while right is source of truth
             when (it) {
                 is Either.Left -> {

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/SourceOfTruthWithBarrier.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/SourceOfTruthWithBarrier.kt
@@ -74,7 +74,7 @@ internal class SourceOfTruthWithBarrier<Key, Input, Output>(
                         } else {
                             null
                         }
-                        val readFlow = when (it) {
+                        val readFlow: Flow<StoreResponse<Output?>> = when (it) {
                             is BarrierMsg.Open -> delegate.reader(key).mapIndexed { index, output ->
                                 if (index == 0 && messageArrivedAfterMe) {
                                     val firstMsgOrigin = if (writeError == null) {
@@ -95,13 +95,13 @@ internal class SourceOfTruthWithBarrier<Key, Input, Output>(
                                     StoreResponse.Data(
                                         origin = ResponseOrigin.SourceOfTruth,
                                         value = output
-                                    )
-                                } as StoreResponse<Output?> // necessary cast for catch block
-                            }.catch {
+                                    ) as StoreResponse<Output?> // necessary cast for catch block
+                                }
+                            }.catch { throwable ->
                                 this.emit(StoreResponse.Error.Exception<Output>(
                                     error = SourceOfTruth.ReadException(
                                         key = key,
-                                        cause = it
+                                        cause = throwable
                                     ),
                                     origin = ResponseOrigin.SourceOfTruth))
                             }


### PR DESCRIPTION
I ran into the same [Duration issue](https://github.com/dropbox/Store/issues/188) after updating Kotlin to `1.4.0-rc` so here's a PR to update Store to compile with kotlin `1.4.0-rc` and revert @chrisbanes 's [workaround](https://github.com/dropbox/Store/issues/188) (tested snapshot artifact locally).

Also fixed a bunch of type inference issues raised by the new compiler.

Update:  just updated to kotlin `1.4.0` and Coroutines `1.3.9`.