### PR TITLE
Resolve Memory Leak

### DIFF
--- a/store/src/main/java/com/dropbox/android/external/store4/impl/RefCountedResource.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/RefCountedResource.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.sync.withLock
  * Simple holder that can ref-count items by a given key.
  */
 internal class RefCountedResource<Key, T>(
-    private val create: suspend (Key) -> T,
+    private val create: (Key) -> T,
     private val onRelease: (suspend (Key, T) -> Unit)? = null
 ) {
     private val items = mutableMapOf<Key, Item>()


### PR DESCRIPTION
Legwork by Zach in (https://github.com/dropbox/Store/issues/197)

Resolve memory leak by removing suspend keyword from RefCountedResource’s create lambda, to prevent it from capture by FetcherController’s onEach()