### PR TITLE
Use absolute path for signing key

### DIFF
--- a/tools/release/deploy_snapshot.sh
+++ b/tools/release/deploy_snapshot.sh
@@ -23,6 +23,6 @@ else
   echo "Deploying store..."
   openssl aes-256-cbc -md sha256 -d -in tools/release/secring.gpg.aes -out tools/release/secring.gpg -k "${ENCRYPT_KEY}"
   # https://docs.gradle.org/current/userguide/signing_plugin.html#sec:signatory_credentials
-  ./gradlew uploadArchives -PSONATYPE_USERNAME="${SONATYPE_USERNAME}" -PSONATYPE_PASSWORD="${SONATYPE_PASSWORD}" -Psigning.keyId="${SIGNING_ID}" -Psigning.password="${SIGNING_PASSWORD}" -Psigning.secretKeyRingFile=tools/release/secring.gpg
+  ./gradlew uploadArchives -PSONATYPE_USERNAME="${SONATYPE_USERNAME}" -PSONATYPE_PASSWORD="${SONATYPE_PASSWORD}" -Psigning.keyId="${SIGNING_ID}" -Psigning.password="${SIGNING_PASSWORD}" -Psigning.secretKeyRingFile=${PWD}/tools/release/secring.gpg
   echo "Store deployed!"
 fi


### PR DESCRIPTION
The deploy failed due to 
```
Unable to retrieve secret key from key ring file '/home/travis/build/dropbox/Store/cache/tools/release/secring.gpg' as it does not exist
```

https://travis-ci.org/github/dropbox/Store/builds/719455200?utm_source=github_status&utm_medium=notification