### PR TITLE
update coroutines to 1.4.0, kotlin to 1.4.10

### DIFF
--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -3,7 +3,7 @@ ext.versions = [
         targetSdk         : 29,
         compileSdk        : 29,
         buildTools        : '29.0.3',
-        kotlin            : '1.4.0',
+        kotlin            : '1.4.10',
         ktlint            : '0.39.0',
 
         // Plugins
@@ -21,7 +21,7 @@ ext.versions = [
         picasso           : '2.5.2',
 
         // Others.
-        coroutines        : '1.3.9',
+        coroutines        : '1.4.0',
         retrofit          : '2.8.1',
         jsr305            : '3.0.2',
         okHttp            : '4.6.0',


### PR DESCRIPTION
This PR updates kotlin and coroutines versions and also removes the last usage of ConflatedBroadcastChannel.