### PR TITLE
Flowable helper factories for get fresh

### DIFF
--- a/store-rx2/api/store-rx2.api
+++ b/store-rx2/api/store-rx2.api
@@ -17,7 +17,9 @@ public final class com/dropbox/store/rx2/RxStoreBuilderKt {
 }
 
 public final class com/dropbox/store/rx2/RxStoreKt {
+	public static final fun freshFlowable (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;)Lio/reactivex/Flowable;
 	public static final fun freshSingle (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;)Lio/reactivex/Single;
+	public static final fun getFlowable (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;)Lio/reactivex/Flowable;
 	public static final fun getSingle (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;)Lio/reactivex/Single;
 	public static final fun observe (Lcom/dropbox/android/external/store4/Store;Lcom/dropbox/android/external/store4/StoreRequest;)Lio/reactivex/Flowable;
 	public static final fun observeClear (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;)Lio/reactivex/Completable;

--- a/store-rx2/src/main/kotlin/com/dropbox/store/rx2/RxStore.kt
+++ b/store-rx2/src/main/kotlin/com/dropbox/store/rx2/RxStore.kt
@@ -6,12 +6,15 @@ import com.dropbox.android.external.store4.StoreBuilder
 import com.dropbox.android.external.store4.StoreRequest
 import com.dropbox.android.external.store4.StoreResponse
 import com.dropbox.android.external.store4.fresh
+import com.dropbox.android.external.store4.freshFlow
 import com.dropbox.android.external.store4.get
+import com.dropbox.android.external.store4.getFlow
 import io.reactivex.Completable
 import io.reactivex.Flowable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.rx2.asFlowable
 import kotlinx.coroutines.rx2.rxCompletable
+import kotlinx.coroutines.rx2.rxFlowable
 import kotlinx.coroutines.rx2.rxSingle
 
 /**
@@ -48,3 +51,19 @@ fun <Key : Any, Output : Any> Store<Key, Output>.getSingle(key: Key) = rxSingle 
  * Helper factory that will return fresh data as a [Single] for [key] while updating your caches
  */
 fun <Key : Any, Output : Any> Store<Key, Output>.freshSingle(key: Key) = rxSingle { this@freshSingle.fresh(key) }
+
+/**
+ * Helper factory that will return stream of data as a [Flowable] for [key] if it is cached
+ * otherwise will return fresh/network data (updating your caches).
+ */
+@ExperimentalCoroutinesApi
+fun <Key : Any, Output : Any> Store<Key, Output>.getFlowable(key: Key): Flowable<Output> =
+    rxFlowable { this@getFlowable.getFlow(key) }
+
+/**
+ * Helper factory that will return a fresh stream of data as a [Flowable] for [key] while updating
+ * your caches.
+ */
+@ExperimentalCoroutinesApi
+fun <Key : Any, Output : Any> Store<Key, Output>.freshFlowable(key: Key): Flowable<Output> =
+    rxFlowable { this@freshFlowable.freshFlow(key) }

--- a/store-rx3/api/store-rx3.api
+++ b/store-rx3/api/store-rx3.api
@@ -17,7 +17,9 @@ public final class com/dropbox/store/rx3/RxStoreBuilderKt {
 }
 
 public final class com/dropbox/store/rx3/RxStoreKt {
+	public static final fun freshFlowable (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;)Lio/reactivex/rxjava3/core/Flowable;
 	public static final fun freshSingle (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;)Lio/reactivex/rxjava3/core/Single;
+	public static final fun getFlowable (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;)Lio/reactivex/rxjava3/core/Flowable;
 	public static final fun getSingle (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;)Lio/reactivex/rxjava3/core/Single;
 	public static final fun observe (Lcom/dropbox/android/external/store4/Store;Lcom/dropbox/android/external/store4/StoreRequest;)Lio/reactivex/rxjava3/core/Flowable;
 	public static final fun observeClear (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;)Lio/reactivex/rxjava3/core/Completable;

--- a/store-rx3/src/main/kotlin/com/dropbox/store/rx3/RxStore.kt
+++ b/store-rx3/src/main/kotlin/com/dropbox/store/rx3/RxStore.kt
@@ -6,12 +6,15 @@ import com.dropbox.android.external.store4.StoreBuilder
 import com.dropbox.android.external.store4.StoreRequest
 import com.dropbox.android.external.store4.StoreResponse
 import com.dropbox.android.external.store4.fresh
+import com.dropbox.android.external.store4.freshFlow
 import com.dropbox.android.external.store4.get
+import com.dropbox.android.external.store4.getFlow
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Flowable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.rx3.asFlowable
 import kotlinx.coroutines.rx3.rxCompletable
+import kotlinx.coroutines.rx3.rxFlowable
 import kotlinx.coroutines.rx3.rxSingle
 
 /**
@@ -50,3 +53,19 @@ fun <Key : Any, Output : Any> Store<Key, Output>.getSingle(key: Key) =
  */
 fun <Key : Any, Output : Any> Store<Key, Output>.freshSingle(key: Key) =
     rxSingle { this@freshSingle.fresh(key) }
+
+/**
+ * Helper factory that will return stream of data as a [Flowable] for [key] if it is cached
+ * otherwise will return fresh/network data (updating your caches).
+ */
+@ExperimentalCoroutinesApi
+fun <Key : Any, Output : Any> Store<Key, Output>.getFlowable(key: Key): Flowable<Output> =
+    rxFlowable { this@getFlowable.getFlow(key) }
+
+/**
+ * Helper factory that will return a fresh stream of data as a [Flowable] for [key] while updating
+ * your caches.
+ */
+@ExperimentalCoroutinesApi
+fun <Key : Any, Output : Any> Store<Key, Output>.freshFlowable(key: Key): Flowable<Output> =
+    rxFlowable { this@freshFlowable.freshFlow(key) }

--- a/store/api/store.api
+++ b/store/api/store.api
@@ -140,7 +140,9 @@ public final class com/dropbox/android/external/store4/StoreBuilder$Companion {
 
 public final class com/dropbox/android/external/store4/StoreKt {
 	public static final fun fresh (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun freshFlow (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun get (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun getFlow (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/dropbox/android/external/store4/StoreRequest {


### PR DESCRIPTION
Addresses #238 .

Note: I'm opening this to get feedback and intend to continue on with this as it is not complete.

- [ ] I need help with writing the appropriate tests for these additions.
- [ ] Get agreement on the naming of these extension functions.
- [ ] There is starting to be some duplication in the extensions that we may wish to address in this PR or in a separate one, discuss.

Regarding the last point I am talking about:

```
suspend fun <Key : Any, Output : Any> Store<Key, Output>.get(key: Key) = stream(
    StoreRequest.cached(key, refresh = false)
).filterNot {
    it is StoreResponse.Loading || it is StoreResponse.NoNewData
}.first().requireData()

// Which looks a lot like the newly added

suspend fun <Key : Any, Output : Any> Store<Key, Output>.getFlow(key: Key): Flow<Output> = stream(
    StoreRequest.cached(key, refresh = false)
).filterNot { it is StoreResponse.Loading || it is StoreResponse.NoNewData }
    .map { it.requireData() } 
```

What I was thinking was modifying the existing `get` extension function to look something like:

```
suspend fun <Key : Any, Output : Any> Store<Key, Output>.get(key: Key) = getFlow(key).first()
```

The same for the other extension functions and possibly even the ones in the `rx` modules. However I didn't want to touch any existing code in this PR. Anyways........ thoughts appreciated.