### PR TITLE
Remove deprecated code to fix error when users upgrade to kotlin 1.5 

### DIFF
--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -3,7 +3,7 @@ ext.versions = [
         targetSdk         : 29,
         compileSdk        : 29,
         buildTools        : '29.0.3',
-        kotlin            : '1.5.0',
+        kotlin            : '1.4.10',
         ktlint            : '0.39.0',
 
         // Plugins
@@ -26,7 +26,7 @@ ext.versions = [
         jsr305            : '3.0.2',
         okHttp            : '4.6.0',
         okio              : '2.6.0',
-        moshi             : '1.12.0',
+        moshi             : '1.9.2',
         appCompat         : '1.1.0',
         fragment          : '1.2.4',
         recyclerView      : '1.1.0',

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -3,7 +3,7 @@ ext.versions = [
         targetSdk         : 29,
         compileSdk        : 29,
         buildTools        : '29.0.3',
-        kotlin            : '1.4.10',
+        kotlin            : '1.5.0',
         ktlint            : '0.39.0',
 
         // Plugins
@@ -26,7 +26,7 @@ ext.versions = [
         jsr305            : '3.0.2',
         okHttp            : '4.6.0',
         okio              : '2.6.0',
-        moshi             : '1.9.2',
+        moshi             : '1.12.0',
         appCompat         : '1.1.0',
         fragment          : '1.2.4',
         recyclerView      : '1.1.0',

--- a/filesystem/src/main/java/com/dropbox/android/external/fs3/filesystem/FileSystemImpl.kt
+++ b/filesystem/src/main/java/com/dropbox/android/external/fs3/filesystem/FileSystemImpl.kt
@@ -74,7 +74,7 @@ internal class FileSystemImpl(private val root: File) : FileSystem {
             return RecordState.MISSING
         }
         val now = System.currentTimeMillis()
-        val cuttOffPoint = now - expirationDuration.toLongMilliseconds()
+        val cuttOffPoint = now - expirationDuration.inWholeMilliseconds
         return if (file.lastModified() < cuttOffPoint) {
             RecordState.STALE
         } else {

--- a/filesystem/src/main/java/com/dropbox/android/external/fs3/filesystem/FileSystemImpl.kt
+++ b/filesystem/src/main/java/com/dropbox/android/external/fs3/filesystem/FileSystemImpl.kt
@@ -9,6 +9,7 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
 import kotlin.time.Duration
+import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 
 /**
@@ -74,7 +75,7 @@ internal class FileSystemImpl(private val root: File) : FileSystem {
             return RecordState.MISSING
         }
         val now = System.currentTimeMillis()
-        val cuttOffPoint = now - expirationDuration.inWholeMilliseconds
+        val cuttOffPoint = now - expirationDuration.toLong(DurationUnit.MILLISECONDS)
         return if (file.lastModified() < cuttOffPoint) {
             RecordState.STALE
         } else {

--- a/store/src/main/java/com/dropbox/android/external/store4/StoreDefaults.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/StoreDefaults.kt
@@ -3,7 +3,6 @@ package com.dropbox.android.external.store4
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
-import kotlin.time.hours
 import kotlin.time.toDuration
 
 @ExperimentalTime

--- a/store/src/main/java/com/dropbox/android/external/store4/StoreDefaults.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/StoreDefaults.kt
@@ -12,7 +12,7 @@ internal object StoreDefaults {
      *
      * @return memory cache TTL
      */
-    val cacheTTL: Duration = 24.hours
+    val cacheTTL: Duration = Duration.hours(24)
 
     /**
      * Cache size (default is 100), can be overridden

--- a/store/src/main/java/com/dropbox/android/external/store4/StoreDefaults.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/StoreDefaults.kt
@@ -1,8 +1,10 @@
 package com.dropbox.android.external.store4
 
 import kotlin.time.Duration
+import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 import kotlin.time.hours
+import kotlin.time.toDuration
 
 @ExperimentalTime
 internal object StoreDefaults {
@@ -12,7 +14,7 @@ internal object StoreDefaults {
      *
      * @return memory cache TTL
      */
-    val cacheTTL: Duration = Duration.hours(24)
+    val cacheTTL: Duration = 24.toDuration(DurationUnit.HOURS)
 
     /**
      * Cache size (default is 100), can be overridden

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.transform
 import java.util.concurrent.TimeUnit
+import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 
 @ExperimentalTime
@@ -65,13 +66,13 @@ internal class RealStore<Key : Any, Input : Any, Output : Any>(
         CacheBuilder.newBuilder().apply {
             if (memoryPolicy.hasAccessPolicy) {
                 expireAfterAccess(
-                    memoryPolicy.expireAfterAccess.inWholeMilliseconds,
+                    memoryPolicy.expireAfterAccess.toLong(DurationUnit.MILLISECONDS),
                     TimeUnit.MILLISECONDS
                 )
             }
             if (memoryPolicy.hasWritePolicy) {
                 expireAfterWrite(
-                    memoryPolicy.expireAfterWrite.inWholeMilliseconds,
+                    memoryPolicy.expireAfterWrite.toLong(DurationUnit.MILLISECONDS),
                     TimeUnit.MILLISECONDS
                 )
             }

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
@@ -65,13 +65,13 @@ internal class RealStore<Key : Any, Input : Any, Output : Any>(
         CacheBuilder.newBuilder().apply {
             if (memoryPolicy.hasAccessPolicy) {
                 expireAfterAccess(
-                    memoryPolicy.expireAfterAccess.toLongMilliseconds(),
+                    memoryPolicy.expireAfterAccess.inWholeMilliseconds,
                     TimeUnit.MILLISECONDS
                 )
             }
             if (memoryPolicy.hasWritePolicy) {
                 expireAfterWrite(
-                    memoryPolicy.expireAfterWrite.toLongMilliseconds(),
+                    memoryPolicy.expireAfterWrite.inWholeMilliseconds,
                     TimeUnit.MILLISECONDS
                 )
             }


### PR DESCRIPTION
Fixes #263 
Unfortunately this is a breaking change. We need to release a new major version. I'll change to store5:5.0 after merge unless someone has a better idea