### PR TITLE
Fire off kotlin 1.5 compatible snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Artifacts are hosted on **Maven Central**.
 
 ```groovy
 def store_version = "4.0.1"
+//if using kotlin 1.5 (https://github.com/dropbox/Store/issues/263)
+def store_version = "4.0.2-KT15-SNAPSHOT" 
 ```
 
 ###### Add the dependency to your `build.gradle`:

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ allprojects {
 ext {
     // POM file
     GROUP = "com.dropbox.mobile.store"
-    VERSION_NAME = "4.0.2-SNAPSHOT"
+    VERSION_NAME = "4.0.2-KT15-SNAPSHOT"
     POM_PACKAGING = "pom"
     POM_DESCRIPTION = "Store4 is built with Kotlin Coroutines"
 
@@ -77,4 +77,3 @@ subprojects {
         }
     }
 }
-

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -3,7 +3,7 @@ ext.versions = [
         targetSdk         : 29,
         compileSdk        : 29,
         buildTools        : '29.0.3',
-        kotlin            : '1.4.10',
+        kotlin            : '1.5.0',
         ktlint            : '0.39.0',
 
         // Plugins
@@ -27,7 +27,7 @@ ext.versions = [
         jsr305            : '3.0.2',
         okHttp            : '4.6.0',
         okio              : '2.6.0',
-        moshi             : '1.9.2',
+        moshi             : '1.12.0',
         appCompat         : '1.1.0',
         fragment          : '1.2.4',
         recyclerView      : '1.1.0',

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -11,7 +11,7 @@ ext.versions = [
         dokkaGradlePlugin           : '0.10.0',
         ktlintGradle                : '9.1.1',
         spotlessGradlePlugin        : '3.26.1',
-        jacocoGradlePlugin          : '0.8.5',
+        jacocoGradlePlugin          : '0.8.7',
         binaryCompatibilityValidator: '0.2.3',
         atomicFuPlugin              : '0.14.2',
 

--- a/filesystem/api/filesystem.api
+++ b/filesystem/api/filesystem.api
@@ -32,21 +32,26 @@ public abstract interface class com/dropbox/android/external/fs3/DiskWrite {
 public final class com/dropbox/android/external/fs3/FSAllEraser : com/dropbox/android/external/fs3/DiskAllErase {
 	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;)V
 	public fun deleteAll (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getFileSystem$filesystem ()Lcom/dropbox/android/external/fs3/filesystem/FileSystem;
 }
 
 public final class com/dropbox/android/external/fs3/FSAllReader : com/dropbox/android/external/fs3/DiskAllRead {
 	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;)V
+	public final fun getFileSystem$filesystem ()Lcom/dropbox/android/external/fs3/filesystem/FileSystem;
 	public fun readAll (Lkotlinx/coroutines/CoroutineScope;Ljava/lang/String;)Lkotlinx/coroutines/channels/ReceiveChannel;
 }
 
 public final class com/dropbox/android/external/fs3/FSEraser : com/dropbox/android/external/fs3/DiskErase {
 	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;)V
 	public fun delete (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getFileSystem$filesystem ()Lcom/dropbox/android/external/fs3/filesystem/FileSystem;
+	public final fun getPathResolver$filesystem ()Lcom/dropbox/android/external/fs3/PathResolver;
 }
 
 public class com/dropbox/android/external/fs3/FSReader : com/dropbox/android/external/fs3/DiskRead {
 	public static final field Companion Lcom/dropbox/android/external/fs3/FSReader$Companion;
 	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;)V
+	public final fun getFileSystem$filesystem ()Lcom/dropbox/android/external/fs3/filesystem/FileSystem;
 	public fun read (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -55,6 +60,7 @@ public final class com/dropbox/android/external/fs3/FSReader$Companion {
 
 public class com/dropbox/android/external/fs3/FSWriter : com/dropbox/android/external/fs3/DiskWrite {
 	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;)V
+	public final fun getFileSystem$filesystem ()Lcom/dropbox/android/external/fs3/filesystem/FileSystem;
 	public synthetic fun write (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun write (Ljava/lang/Object;Lokio/BufferedSource;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -73,7 +79,7 @@ public final class com/dropbox/android/external/fs3/FileSystemPersister$Companio
 
 public final class com/dropbox/android/external/fs3/FileSystemRecordPersister : com/dropbox/android/external/fs3/Persister, com/dropbox/android/external/fs3/RecordProvider {
 	public static final field Companion Lcom/dropbox/android/external/fs3/FileSystemRecordPersister$Companion;
-	public synthetic fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;DLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getRecordState (Ljava/lang/Object;)Lcom/dropbox/android/external/fs3/RecordState;
 	public fun read (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun write (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -81,7 +87,7 @@ public final class com/dropbox/android/external/fs3/FileSystemRecordPersister : 
 }
 
 public final class com/dropbox/android/external/fs3/FileSystemRecordPersister$Companion {
-	public final fun create--X5_uIg (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;D)Lcom/dropbox/android/external/fs3/FileSystemRecordPersister;
+	public final fun create-SxA4cEA (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;J)Lcom/dropbox/android/external/fs3/FileSystemRecordPersister;
 }
 
 public abstract interface class com/dropbox/android/external/fs3/PathResolver {
@@ -95,19 +101,19 @@ public abstract interface class com/dropbox/android/external/fs3/Persister : com
 
 public final class com/dropbox/android/external/fs3/RecordPersister : com/dropbox/android/external/fs3/SourcePersister, com/dropbox/android/external/fs3/RecordProvider {
 	public static final field Companion Lcom/dropbox/android/external/fs3/RecordPersister$Companion;
-	public synthetic fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;DLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun getRecordState (Ljava/lang/Object;)Lcom/dropbox/android/external/fs3/RecordState;
 	public fun getRecordState (Lkotlin/Pair;)Lcom/dropbox/android/external/fs3/RecordState;
 }
 
 public final class com/dropbox/android/external/fs3/RecordPersister$Companion {
-	public final fun create-7TrAQF4 (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;D)Lcom/dropbox/android/external/fs3/RecordPersister;
+	public final fun create-HG0u8IE (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;J)Lcom/dropbox/android/external/fs3/RecordPersister;
 }
 
 public final class com/dropbox/android/external/fs3/RecordPersisterFactory {
 	public static final field INSTANCE Lcom/dropbox/android/external/fs3/RecordPersisterFactory;
-	public final fun create-7TrAQF4 (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;D)Lcom/dropbox/android/external/fs3/Persister;
-	public final fun create-bn-UTRM (Ljava/io/File;D)Lcom/dropbox/android/external/fs3/Persister;
+	public final fun create-HG0u8IE (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;J)Lcom/dropbox/android/external/fs3/Persister;
+	public final fun create-HG0u8IE (Ljava/io/File;J)Lcom/dropbox/android/external/fs3/Persister;
 }
 
 public abstract interface class com/dropbox/android/external/fs3/RecordProvider {
@@ -126,6 +132,10 @@ public final class com/dropbox/android/external/fs3/SourceAllPersister : com/dro
 	public static final field Companion Lcom/dropbox/android/external/fs3/SourceAllPersister$Companion;
 	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;)V
 	public fun deleteAll (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getSourceFileAllEraser$filesystem ()Lcom/dropbox/android/external/fs3/FSAllEraser;
+	public final fun getSourceFileAllReader$filesystem ()Lcom/dropbox/android/external/fs3/FSAllReader;
+	public final fun getSourceFileReader$filesystem ()Lcom/dropbox/android/external/fs3/FSReader;
+	public final fun getSourceFileWriter$filesystem ()Lcom/dropbox/android/external/fs3/FSWriter;
 	public synthetic fun read (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun read (Lkotlin/Pair;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun readAll (Lkotlinx/coroutines/CoroutineScope;Ljava/lang/String;)Lkotlinx/coroutines/channels/ReceiveChannel;
@@ -141,7 +151,7 @@ public final class com/dropbox/android/external/fs3/SourceFileReader : com/dropb
 	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;)V
 	public fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;)V
 	public synthetic fun <init> (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;Lcom/dropbox/android/external/fs3/PathResolver;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getRecordState-7oCP4Nc (Lkotlin/Pair;D)Lcom/dropbox/android/external/fs3/RecordState;
+	public final fun getRecordState-HG0u8IE (Lkotlin/Pair;J)Lcom/dropbox/android/external/fs3/RecordState;
 }
 
 public final class com/dropbox/android/external/fs3/SourceFileWriter : com/dropbox/android/external/fs3/FSWriter, com/dropbox/android/external/fs3/DiskWrite {
@@ -163,14 +173,15 @@ public class com/dropbox/android/external/fs3/SourcePersister : com/dropbox/andr
 
 public final class com/dropbox/android/external/fs3/SourcePersister$Companion {
 	public final fun create (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;)Lcom/dropbox/android/external/fs3/SourcePersister;
+	public final fun pathForBarcode$filesystem (Lkotlin/Pair;)Ljava/lang/String;
 }
 
 public final class com/dropbox/android/external/fs3/SourcePersisterFactory {
 	public static final field INSTANCE Lcom/dropbox/android/external/fs3/SourcePersisterFactory;
 	public final fun create (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;)Lcom/dropbox/android/external/fs3/Persister;
 	public final fun create (Ljava/io/File;)Lcom/dropbox/android/external/fs3/Persister;
-	public final fun create-7TrAQF4 (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;D)Lcom/dropbox/android/external/fs3/Persister;
-	public final fun create-bn-UTRM (Ljava/io/File;D)Lcom/dropbox/android/external/fs3/Persister;
+	public final fun create-HG0u8IE (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;J)Lcom/dropbox/android/external/fs3/Persister;
+	public final fun create-HG0u8IE (Ljava/io/File;J)Lcom/dropbox/android/external/fs3/Persister;
 	public final fun createAll (Lcom/dropbox/android/external/fs3/filesystem/FileSystem;)Lcom/dropbox/android/external/fs3/Persister;
 	public final fun createAll (Ljava/io/File;)Lcom/dropbox/android/external/fs3/Persister;
 }
@@ -193,11 +204,28 @@ public final class com/dropbox/android/external/fs3/Util {
 	public final fun simplifyPath (Ljava/lang/String;)Ljava/lang/String;
 }
 
+public final class com/dropbox/android/external/fs3/filesystem/BreadthFirstFileTreeIterator : java/util/Iterator, kotlin/jvm/internal/markers/KMappedMarker {
+	public fun <init> (Ljava/io/File;)V
+	public fun hasNext ()Z
+	public fun next ()Ljava/lang/Object;
+	public fun remove ()V
+}
+
+public final class com/dropbox/android/external/fs3/filesystem/FSFile {
+	public fun <init> (Ljava/io/File;Ljava/lang/String;)V
+	public final fun delete ()V
+	public final fun exists ()Z
+	public final fun lastModified ()J
+	public final fun path ()Ljava/lang/String;
+	public final fun source ()Lokio/BufferedSource;
+	public final fun write (Lokio/BufferedSource;)V
+}
+
 public abstract interface class com/dropbox/android/external/fs3/filesystem/FileSystem {
 	public abstract fun delete (Ljava/lang/String;)V
 	public abstract fun deleteAll (Ljava/lang/String;)V
 	public abstract fun exists (Ljava/lang/String;)Z
-	public abstract fun getRecordState-Tv7q0oI (DLjava/lang/String;)Lcom/dropbox/android/external/fs3/RecordState;
+	public abstract fun getRecordState-VtjQ1oo (JLjava/lang/String;)Lcom/dropbox/android/external/fs3/RecordState;
 	public abstract fun list (Ljava/lang/String;)Ljava/util/Collection;
 	public abstract fun read (Ljava/lang/String;)Lokio/BufferedSource;
 	public abstract fun write (Ljava/lang/String;Lokio/BufferedSource;)V
@@ -206,5 +234,16 @@ public abstract interface class com/dropbox/android/external/fs3/filesystem/File
 public final class com/dropbox/android/external/fs3/filesystem/FileSystemFactory {
 	public static final field INSTANCE Lcom/dropbox/android/external/fs3/filesystem/FileSystemFactory;
 	public final fun create (Ljava/io/File;)Lcom/dropbox/android/external/fs3/filesystem/FileSystem;
+}
+
+public final class com/dropbox/android/external/fs3/filesystem/FileSystemImpl : com/dropbox/android/external/fs3/filesystem/FileSystem {
+	public fun <init> (Ljava/io/File;)V
+	public fun delete (Ljava/lang/String;)V
+	public fun deleteAll (Ljava/lang/String;)V
+	public fun exists (Ljava/lang/String;)Z
+	public fun getRecordState-VtjQ1oo (JLjava/lang/String;)Lcom/dropbox/android/external/fs3/RecordState;
+	public fun list (Ljava/lang/String;)Ljava/util/Collection;
+	public fun read (Ljava/lang/String;)Lokio/BufferedSource;
+	public fun write (Ljava/lang/String;Lokio/BufferedSource;)V
 }
 

--- a/filesystem/src/main/java/com/dropbox/android/external/fs3/filesystem/FileSystemImpl.kt
+++ b/filesystem/src/main/java/com/dropbox/android/external/fs3/filesystem/FileSystemImpl.kt
@@ -9,7 +9,6 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
 import kotlin.time.Duration
-import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 
 /**
@@ -75,7 +74,7 @@ internal class FileSystemImpl(private val root: File) : FileSystem {
             return RecordState.MISSING
         }
         val now = System.currentTimeMillis()
-        val cuttOffPoint = now - expirationDuration.inWholeMilliseconds
+        val cuttOffPoint: Long = now - expirationDuration.inWholeMilliseconds
         return if (file.lastModified() < cuttOffPoint) {
             RecordState.STALE
         } else {

--- a/filesystem/src/main/java/com/dropbox/android/external/fs3/filesystem/FileSystemImpl.kt
+++ b/filesystem/src/main/java/com/dropbox/android/external/fs3/filesystem/FileSystemImpl.kt
@@ -75,7 +75,7 @@ internal class FileSystemImpl(private val root: File) : FileSystem {
             return RecordState.MISSING
         }
         val now = System.currentTimeMillis()
-        val cuttOffPoint = now - expirationDuration.toLong(DurationUnit.MILLISECONDS)
+        val cuttOffPoint = now - expirationDuration.inWholeMilliseconds
         return if (file.lastModified() < cuttOffPoint) {
             RecordState.STALE
         } else {

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -4,6 +4,10 @@
 
 // Enables code coverage for JVM tests.
 apply plugin: "jacoco"
+
+jacoco {
+    toolVersion = "0.8.7"
+}
 // Android Gradle Plugin out of the box supports only code coverage for instrumentation tests.
 // Creates a task that will merge coverage for all projects
 project.afterEvaluate {

--- a/multicast/api/multicast.api
+++ b/multicast/api/multicast.api
@@ -1,8 +1,93 @@
+public final class com/dropbox/flow/multicast/ChannelManager {
+	public fun <init> (Lkotlinx/coroutines/CoroutineScope;IZZLkotlin/jvm/functions/Function2;Lkotlinx/coroutines/flow/Flow;)V
+	public synthetic fun <init> (Lkotlinx/coroutines/CoroutineScope;IZZLkotlin/jvm/functions/Function2;Lkotlinx/coroutines/flow/Flow;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun addDownstream (Lkotlinx/coroutines/channels/SendChannel;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun addDownstream$default (Lcom/dropbox/flow/multicast/ChannelManager;Lkotlinx/coroutines/channels/SendChannel;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun removeDownstream (Lkotlinx/coroutines/channels/SendChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/dropbox/flow/multicast/ChannelManager$ChannelEntry {
+	public fun <init> (Lkotlinx/coroutines/channels/SendChannel;Z)V
+	public synthetic fun <init> (Lkotlinx/coroutines/channels/SendChannel;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun close ()V
+	public final fun component2 ()Z
+	public final fun copy (Lkotlinx/coroutines/channels/SendChannel;Z)Lcom/dropbox/flow/multicast/ChannelManager$ChannelEntry;
+	public static synthetic fun copy$default (Lcom/dropbox/flow/multicast/ChannelManager$ChannelEntry;Lkotlinx/coroutines/channels/SendChannel;ZILjava/lang/Object;)Lcom/dropbox/flow/multicast/ChannelManager$ChannelEntry;
+	public final fun dispatchError (Ljava/lang/Throwable;)V
+	public final fun dispatchValue (Lcom/dropbox/flow/multicast/ChannelManager$Message$Dispatch$Value;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAwaitsDispatch ()Z
+	public final fun getPiggybackOnly ()Z
+	public final fun hasChannel (Lcom/dropbox/flow/multicast/ChannelManager$ChannelEntry;)Z
+	public final fun hasChannel (Lkotlinx/coroutines/channels/SendChannel;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/dropbox/flow/multicast/ChannelManager$Message {
+}
+
+public final class com/dropbox/flow/multicast/ChannelManager$Message$AddChannel : com/dropbox/flow/multicast/ChannelManager$Message {
+	public fun <init> (Lkotlinx/coroutines/channels/SendChannel;Z)V
+	public synthetic fun <init> (Lkotlinx/coroutines/channels/SendChannel;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getChannel ()Lkotlinx/coroutines/channels/SendChannel;
+	public final fun getPiggybackOnly ()Z
+}
+
+public abstract class com/dropbox/flow/multicast/ChannelManager$Message$Dispatch : com/dropbox/flow/multicast/ChannelManager$Message {
+}
+
+public final class com/dropbox/flow/multicast/ChannelManager$Message$Dispatch$Error : com/dropbox/flow/multicast/ChannelManager$Message$Dispatch {
+	public fun <init> (Ljava/lang/Throwable;)V
+	public final fun getError ()Ljava/lang/Throwable;
+}
+
+public final class com/dropbox/flow/multicast/ChannelManager$Message$Dispatch$UpstreamFinished : com/dropbox/flow/multicast/ChannelManager$Message$Dispatch {
+	public fun <init> (Lcom/dropbox/flow/multicast/SharedFlowProducer;)V
+	public final fun getProducer ()Lcom/dropbox/flow/multicast/SharedFlowProducer;
+}
+
+public final class com/dropbox/flow/multicast/ChannelManager$Message$Dispatch$Value : com/dropbox/flow/multicast/ChannelManager$Message$Dispatch {
+	public fun <init> (Ljava/lang/Object;Lkotlinx/coroutines/CompletableDeferred;)V
+	public final fun getDelivered ()Lkotlinx/coroutines/CompletableDeferred;
+	public final fun getValue ()Ljava/lang/Object;
+}
+
+public final class com/dropbox/flow/multicast/ChannelManager$Message$RemoveChannel : com/dropbox/flow/multicast/ChannelManager$Message {
+	public fun <init> (Lkotlinx/coroutines/channels/SendChannel;)V
+	public final fun getChannel ()Lkotlinx/coroutines/channels/SendChannel;
+}
+
+public final class com/dropbox/flow/multicast/ChannelManagerKt {
+	public static final fun markDelivered (Lcom/dropbox/flow/multicast/ChannelManager$Message$Dispatch$Value;)Z
+}
+
 public final class com/dropbox/flow/multicast/Multicaster {
 	public fun <init> (Lkotlinx/coroutines/CoroutineScope;ILkotlinx/coroutines/flow/Flow;ZZLkotlin/jvm/functions/Function2;)V
 	public synthetic fun <init> (Lkotlinx/coroutines/CoroutineScope;ILkotlinx/coroutines/flow/Flow;ZZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun newDownstream (Z)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun newDownstream$default (Lcom/dropbox/flow/multicast/Multicaster;ZILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/dropbox/flow/multicast/SharedFlowProducer {
+	public fun <init> (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)V
+	public final fun cancel ()V
+	public final fun cancelAndJoin (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun start ()V
+}
+
+public abstract class com/dropbox/flow/multicast/StoreRealActor {
+	public static final field Companion Lcom/dropbox/flow/multicast/StoreRealActor$Companion;
+	public fun <init> (Lkotlinx/coroutines/CoroutineScope;)V
+	public final fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun handle (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onClosed ()V
+	public final fun send (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/dropbox/flow/multicast/StoreRealActor$Companion {
+	public final fun getCLOSE_TOKEN ()Ljava/lang/Object;
 }
 

--- a/store/api/store.api
+++ b/store/api/store.api
@@ -1,3 +1,11 @@
+public final class com/dropbox/android/external/store4/CacheType : java/lang/Enum {
+	public static final field DISK Lcom/dropbox/android/external/store4/CacheType;
+	public static final field MEMORY Lcom/dropbox/android/external/store4/CacheType;
+	public final fun getFlag$store ()I
+	public static fun valueOf (Ljava/lang/String;)Lcom/dropbox/android/external/store4/CacheType;
+	public static fun values ()[Lcom/dropbox/android/external/store4/CacheType;
+}
+
 public abstract interface annotation class com/dropbox/android/external/store4/ExperimentalStoreApi : java/lang/annotation/Annotation {
 }
 
@@ -55,8 +63,9 @@ public final class com/dropbox/android/external/store4/FetcherResult$Error$Messa
 public final class com/dropbox/android/external/store4/MemoryPolicy {
 	public static final field Companion Lcom/dropbox/android/external/store4/MemoryPolicy$Companion;
 	public static final field DEFAULT_SIZE_POLICY J
-	public final fun getExpireAfterAccess-UwyO8pc ()D
-	public final fun getExpireAfterWrite-UwyO8pc ()D
+	public synthetic fun <init> (JJJJLcom/dropbox/android/external/store4/Weigher;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getExpireAfterAccess-UwyO8pc ()J
+	public final fun getExpireAfterWrite-UwyO8pc ()J
 	public final fun getHasAccessPolicy ()Z
 	public final fun getHasMaxSize ()Z
 	public final fun getHasMaxWeight ()Z
@@ -69,16 +78,21 @@ public final class com/dropbox/android/external/store4/MemoryPolicy {
 
 public final class com/dropbox/android/external/store4/MemoryPolicy$Companion {
 	public final fun builder ()Lcom/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder;
-	public final fun getDEFAULT_DURATION_POLICY-UwyO8pc ()D
+	public final fun getDEFAULT_DURATION_POLICY-UwyO8pc ()J
 }
 
 public final class com/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder {
 	public fun <init> ()V
 	public final fun build ()Lcom/dropbox/android/external/store4/MemoryPolicy;
-	public final fun setExpireAfterAccess-LRDsOJo (D)Lcom/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder;
-	public final fun setExpireAfterWrite-LRDsOJo (D)Lcom/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder;
+	public final fun setExpireAfterAccess-LRDsOJo (J)Lcom/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder;
+	public final fun setExpireAfterWrite-LRDsOJo (J)Lcom/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder;
 	public final fun setMaxSize (J)Lcom/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder;
 	public final fun setWeigherAndMaxWeight (Lcom/dropbox/android/external/store4/Weigher;J)Lcom/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder;
+}
+
+public final class com/dropbox/android/external/store4/OneWeigher : com/dropbox/android/external/store4/Weigher {
+	public static final field INSTANCE Lcom/dropbox/android/external/store4/OneWeigher;
+	public fun weigh (Ljava/lang/Object;Ljava/lang/Object;)I
 }
 
 public final class com/dropbox/android/external/store4/ResponseOrigin : java/lang/Enum {
@@ -138,6 +152,13 @@ public final class com/dropbox/android/external/store4/StoreBuilder$Companion {
 	public final fun from (Lcom/dropbox/android/external/store4/Fetcher;Lcom/dropbox/android/external/store4/SourceOfTruth;)Lcom/dropbox/android/external/store4/StoreBuilder;
 }
 
+public final class com/dropbox/android/external/store4/StoreDefaults {
+	public static final field INSTANCE Lcom/dropbox/android/external/store4/StoreDefaults;
+	public final fun getCacheSize ()J
+	public final fun getCacheTTL-UwyO8pc ()J
+	public final fun getMemoryPolicy ()Lcom/dropbox/android/external/store4/MemoryPolicy;
+}
+
 public final class com/dropbox/android/external/store4/StoreKt {
 	public static final fun fresh (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun get (Lcom/dropbox/android/external/store4/Store;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -154,6 +175,7 @@ public final class com/dropbox/android/external/store4/StoreRequest {
 	public final fun getKey ()Ljava/lang/Object;
 	public final fun getRefresh ()Z
 	public fun hashCode ()I
+	public final fun shouldSkipCache$store (Lcom/dropbox/android/external/store4/CacheType;)Z
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -168,6 +190,7 @@ public abstract class com/dropbox/android/external/store4/StoreResponse {
 	public final fun errorMessageOrNull ()Ljava/lang/String;
 	public abstract fun getOrigin ()Lcom/dropbox/android/external/store4/ResponseOrigin;
 	public final fun requireData ()Ljava/lang/Object;
+	public final fun swapType$store ()Lcom/dropbox/android/external/store4/StoreResponse;
 	public final fun throwIfError ()V
 }
 
@@ -241,5 +264,92 @@ public final class com/dropbox/android/external/store4/StoreResponseKt {
 
 public abstract interface class com/dropbox/android/external/store4/Weigher {
 	public abstract fun weigh (Ljava/lang/Object;Ljava/lang/Object;)I
+}
+
+public final class com/dropbox/android/external/store4/impl/FetcherController {
+	public fun <init> (Lkotlinx/coroutines/CoroutineScope;Lcom/dropbox/android/external/store4/Fetcher;Lcom/dropbox/android/external/store4/impl/SourceOfTruthWithBarrier;)V
+	public final fun fetcherSize$store (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getFetcher (Ljava/lang/Object;Z)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getFetcher$default (Lcom/dropbox/android/external/store4/impl/FetcherController;Ljava/lang/Object;ZILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/dropbox/android/external/store4/impl/PersistentNonFlowingSourceOfTruth : com/dropbox/android/external/store4/SourceOfTruth {
+	public fun <init> (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun delete (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun deleteAll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun reader (Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public fun write (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/dropbox/android/external/store4/impl/PersistentSourceOfTruth : com/dropbox/android/external/store4/SourceOfTruth {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun delete (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun deleteAll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun reader (Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public fun write (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/dropbox/android/external/store4/impl/RealStore : com/dropbox/android/external/store4/Store {
+	public fun <init> (Lkotlinx/coroutines/CoroutineScope;Lcom/dropbox/android/external/store4/Fetcher;Lcom/dropbox/android/external/store4/SourceOfTruth;Lcom/dropbox/android/external/store4/MemoryPolicy;)V
+	public synthetic fun <init> (Lkotlinx/coroutines/CoroutineScope;Lcom/dropbox/android/external/store4/Fetcher;Lcom/dropbox/android/external/store4/SourceOfTruth;Lcom/dropbox/android/external/store4/MemoryPolicy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun clear (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun clearAll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun stream (Lcom/dropbox/android/external/store4/StoreRequest;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/dropbox/android/external/store4/impl/RefCountedResource {
+	public fun <init> (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun acquire (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun release (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun size (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/dropbox/android/external/store4/impl/SourceOfTruthWithBarrier {
+	public static final field Companion Lcom/dropbox/android/external/store4/impl/SourceOfTruthWithBarrier$Companion;
+	public fun <init> (Lcom/dropbox/android/external/store4/SourceOfTruth;)V
+	public final fun barrierCount$store (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun delete (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun deleteAll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun reader (Ljava/lang/Object;Lkotlinx/coroutines/CompletableDeferred;)Lkotlinx/coroutines/flow/Flow;
+	public final fun write (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/dropbox/android/external/store4/impl/SourceOfTruthWithBarrier$Companion {
+}
+
+public abstract class com/dropbox/android/external/store4/impl/operators/Either {
+}
+
+public final class com/dropbox/android/external/store4/impl/operators/Either$Left : com/dropbox/android/external/store4/impl/operators/Either {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lcom/dropbox/android/external/store4/impl/operators/Either$Left;
+	public static synthetic fun copy$default (Lcom/dropbox/android/external/store4/impl/operators/Either$Left;Ljava/lang/Object;ILjava/lang/Object;)Lcom/dropbox/android/external/store4/impl/operators/Either$Left;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/dropbox/android/external/store4/impl/operators/Either$Right : com/dropbox/android/external/store4/impl/operators/Either {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lcom/dropbox/android/external/store4/impl/operators/Either$Right;
+	public static synthetic fun copy$default (Lcom/dropbox/android/external/store4/impl/operators/Either$Right;Ljava/lang/Object;ILjava/lang/Object;)Lcom/dropbox/android/external/store4/impl/operators/Either$Right;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/dropbox/android/external/store4/impl/operators/FlowMergeKt {
+	public static final fun merge (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/dropbox/android/external/store4/impl/operators/MapIndexedKt {
+	public static final fun mapIndexed (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
 }
 

--- a/store/src/main/java/com/dropbox/android/external/store4/StoreDefaults.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/StoreDefaults.kt
@@ -1,9 +1,7 @@
 package com.dropbox.android.external.store4
 
 import kotlin.time.Duration
-import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
-import kotlin.time.toDuration
 
 @ExperimentalTime
 internal object StoreDefaults {

--- a/store/src/main/java/com/dropbox/android/external/store4/StoreDefaults.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/StoreDefaults.kt
@@ -13,7 +13,7 @@ internal object StoreDefaults {
      *
      * @return memory cache TTL
      */
-    val cacheTTL: Duration = 24.toDuration(DurationUnit.HOURS)
+    val cacheTTL: Duration = Duration.hours(24)
 
     /**
      * Cache size (default is 100), can be overridden

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
@@ -66,13 +66,13 @@ internal class RealStore<Key : Any, Input : Any, Output : Any>(
         CacheBuilder.newBuilder().apply {
             if (memoryPolicy.hasAccessPolicy) {
                 expireAfterAccess(
-                    memoryPolicy.expireAfterAccess.toLong(DurationUnit.MILLISECONDS),
+                    memoryPolicy.expireAfterAccess.inWholeMilliseconds,
                     TimeUnit.MILLISECONDS
                 )
             }
             if (memoryPolicy.hasWritePolicy) {
                 expireAfterWrite(
-                    memoryPolicy.expireAfterWrite.toLong(DurationUnit.MILLISECONDS),
+                    memoryPolicy.expireAfterWrite.inWholeMilliseconds,
                     TimeUnit.MILLISECONDS
                 )
             }

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
@@ -38,7 +38,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.transform
 import java.util.concurrent.TimeUnit
-import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 
 @ExperimentalTime


### PR DESCRIPTION
* Upgrade to kotlin 1.5
* fix Jacoco compat issue
* change snapshot version to 4.0.2-KT15-SNAPSHOT (will auto release post merge)
* * validate all tests pass, update api checks (1.5 changed functions)

fixes #263 which had crashes due to kotlin 1.5 duration class type changes.

We will try to release 1.4 compatible and 1.5 compatible changes for next few months. We will eventually stop supporting 1.4 and instead release only 1.5 compatible versions.
