### PR TITLE
Bug Fix: Sample App - Conflicting Kotlin Versions (1.4.x & 1.5.x)

### DIFF
--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -16,7 +16,7 @@ ext.versions = [
         atomicFuPlugin              : '0.14.2',
 
         cache                       : '3.1.1',
-        store                       : '4.0.1',
+        store                       : '4.0.2-KT15',
 
         // UI libs.
         picasso           : '2.5.2',


### PR DESCRIPTION
There are runtime errors with the sample "app" module due to conflicting Kotlin versions.  We need to upgrade Store to 4.0.2-KT15 so that 1.5.21 is used.
---
CLA Note: I just filled out the form.
