### PR TITLE
Remove Unnecessary Kotlin Experimental & Preview Annotations

### DIFF
--- a/app/src/main/java/com/dropbox/android/sample/Graph.kt
+++ b/app/src/main/java/com/dropbox/android/sample/Graph.kt
@@ -19,8 +19,6 @@ import com.dropbox.android.sample.data.model.RedditDb
 import com.dropbox.android.sample.data.remote.Api
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import okio.Buffer
@@ -33,8 +31,6 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.seconds
 
 @OptIn(
-    FlowPreview::class,
-    ExperimentalCoroutinesApi::class,
     ExperimentalTime::class,
     ExperimentalStdlibApi::class
 )

--- a/app/src/main/java/com/dropbox/android/sample/ui/reddit/RedditViewModel.kt
+++ b/app/src/main/java/com/dropbox/android/sample/ui/reddit/RedditViewModel.kt
@@ -9,11 +9,8 @@ import com.dropbox.android.external.store4.get
 import com.dropbox.android.sample.SampleApp
 import com.dropbox.android.sample.data.model.Post
 import com.dropbox.android.sample.utils.Lce
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.launch
 
-@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 class RedditViewModel(
     app: Application
 ) : AndroidViewModel(app) {

--- a/app/src/main/java/com/dropbox/android/sample/ui/room/RoomFragment.kt
+++ b/app/src/main/java/com/dropbox/android/sample/ui/room/RoomFragment.kt
@@ -16,8 +16,6 @@ import com.dropbox.android.sample.reddit.PostAdapter
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.activity_store.postRecyclerView
 import kotlinx.android.synthetic.main.fragment_room_store.*
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.consumeAsFlow
@@ -26,7 +24,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.launch
 
-@FlowPreview
 class RoomFragment : Fragment() {
 
     override fun onCreateView(
@@ -37,13 +34,11 @@ class RoomFragment : Fragment() {
         return inflater.inflate(R.layout.fragment_room_store, container, false)
     }
 
-    @ExperimentalCoroutinesApi
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initUI()
     }
 
-    @ExperimentalCoroutinesApi
     private fun initUI() {
         val adapter = PostAdapter()
         // lazily set the adapter when we have data the first time so that RecyclerView can
@@ -99,7 +94,6 @@ class RoomFragment : Fragment() {
 /**
  * This class should possibly be moved to a helper library but needs more API work before that.
  */
-@ExperimentalCoroutinesApi
 internal class StoreState<Key : Any, Output : Any>(
     private val store: Store<Key, Output>
 ) {

--- a/app/src/main/java/com/dropbox/android/sample/ui/stream/StreamFragment.kt
+++ b/app/src/main/java/com/dropbox/android/sample/ui/stream/StreamFragment.kt
@@ -15,9 +15,6 @@ import com.dropbox.android.sample.R
 import kotlinx.android.synthetic.main.fragment_stream.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -29,7 +26,7 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.time.ExperimentalTime
 import kotlin.time.seconds
 
-@ExperimentalCoroutinesApi
+@ExperimentalTime
 class StreamFragment : Fragment(), CoroutineScope {
 
     override val coroutineContext: CoroutineContext = Job() + Dispatchers.Main
@@ -42,9 +39,6 @@ class StreamFragment : Fragment(), CoroutineScope {
         return inflater.inflate(R.layout.fragment_stream, container, false)
     }
 
-    @ExperimentalTime
-    @InternalCoroutinesApi
-    @FlowPreview
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/filesystem/src/main/java/com/dropbox/android/external/fs3/FSAllReader.kt
+++ b/filesystem/src/main/java/com/dropbox/android/external/fs3/FSAllReader.kt
@@ -2,7 +2,6 @@ package com.dropbox.android.external.fs3
 
 import com.dropbox.android.external.fs3.filesystem.FileSystem
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.produce
 import okio.BufferedSource
@@ -14,7 +13,6 @@ import java.io.FileNotFoundException
  * Make sure to have keys containing same data resolve to same "path"
  *
  */
-@ExperimentalCoroutinesApi
 class FSAllReader(internal val fileSystem: FileSystem) : DiskAllRead<BufferedSource> {
 
     @Throws(FileNotFoundException::class)

--- a/filesystem/src/main/java/com/dropbox/android/external/fs3/SourceAllPersister.kt
+++ b/filesystem/src/main/java/com/dropbox/android/external/fs3/SourceAllPersister.kt
@@ -2,12 +2,10 @@ package com.dropbox.android.external.fs3
 
 import com.dropbox.android.external.fs3.filesystem.FileSystem
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.ReceiveChannel
 import okio.BufferedSource
 import java.io.FileNotFoundException
 
-@ExperimentalCoroutinesApi
 class SourceAllPersister(fileSystem: FileSystem) : AllPersister<BufferedSource, Pair<String, String>> {
 
     internal val sourceFileAllReader: FSAllReader = FSAllReader(fileSystem)

--- a/filesystem/src/main/java/com/dropbox/android/external/fs3/SourcePersisterFactory.kt
+++ b/filesystem/src/main/java/com/dropbox/android/external/fs3/SourcePersisterFactory.kt
@@ -2,7 +2,6 @@ package com.dropbox.android.external.fs3
 
 import com.dropbox.android.external.fs3.filesystem.FileSystem
 import com.dropbox.android.external.fs3.filesystem.FileSystemFactory
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import okio.BufferedSource
 import java.io.File
 import java.io.IOException
@@ -13,7 +12,6 @@ import kotlin.time.ExperimentalTime
  * Factory for [SourcePersister]
  */
 
-@ExperimentalCoroutinesApi
 object SourcePersisterFactory {
 
     /**

--- a/filesystem/src/test/java/com/dropbox/android/external/fs3/FSAllOperationTest.kt
+++ b/filesystem/src/test/java/com/dropbox/android/external/fs3/FSAllOperationTest.kt
@@ -4,7 +4,6 @@ import com.dropbox.android.external.fs3.filesystem.FileSystemFactory
 import com.google.common.base.Charsets.UTF_8
 import com.google.common.io.Files.createTempDir
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import okio.BufferedSource
 import okio.buffer
@@ -12,7 +11,6 @@ import okio.source
 import org.junit.Test
 import java.io.ByteArrayInputStream
 
-@ExperimentalCoroutinesApi
 class FSAllOperationTest {
 
     @Test

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/ChannelManager.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/ChannelManager.kt
@@ -19,7 +19,6 @@ package com.dropbox.flow.multicast
 import com.dropbox.flow.multicast.ChannelManager.Message
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
 
@@ -401,6 +400,5 @@ private class BufferImpl<T>(private val limit: Int) :
     }
 }
 
-@ExperimentalCoroutinesApi
 internal fun <T> ChannelManager.Message.Dispatch.Value<T>.markDelivered() =
     delivered.complete(Unit)

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/Multicaster.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/Multicaster.kt
@@ -17,7 +17,6 @@
 package com.dropbox.flow.multicast
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.flow.Flow
@@ -35,7 +34,6 @@ import kotlinx.coroutines.flow.transform
  * downstream value collects the latest dispatched value OR a new downstream is added while [buffer]
  * is empty.
  */
-@ExperimentalCoroutinesApi
 class Multicaster<T>(
     /**
      * The [CoroutineScope] to use for upstream subscription

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerTest.kt
@@ -16,7 +16,6 @@
 package com.dropbox.flow.multicast
 
 import com.dropbox.flow.multicast.ChannelManager.Message.Dispatch
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
@@ -35,7 +34,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
-@ExperimentalCoroutinesApi
 class ChannelManagerTest {
     private val scope = TestCoroutineScope()
     private val upstream: Channel<String> = Channel(Channel.UNLIMITED)

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/InfiniteMulticastTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/InfiniteMulticastTest.kt
@@ -15,7 +15,6 @@
  */
 package com.dropbox.flow.multicast
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -35,7 +34,6 @@ import kotlin.test.assertEquals
  * It basically waits until there is another reason to enable upstream and will receive those
  * values as well.
  */
-@ExperimentalCoroutinesApi
 class InfiniteMulticastTest {
     private val testScope = TestCoroutineScope()
     private val dispatchLog = mutableListOf<String>()

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/MulticastTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/MulticastTest.kt
@@ -16,7 +16,6 @@
 package com.dropbox.flow.multicast
 
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -43,7 +42,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-@ExperimentalCoroutinesApi
 class MulticastTest {
     private val testScope = TestCoroutineScope()
 

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/SharedFlowProducerTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/SharedFlowProducerTest.kt
@@ -15,7 +15,6 @@
  */
 package com.dropbox.flow.multicast
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestCoroutineScope
@@ -23,7 +22,6 @@ import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-@ExperimentalCoroutinesApi
 class SharedFlowProducerTest {
     private val scope = TestCoroutineScope()
     private val upstreamMessages = mutableListOf<String>()

--- a/store-rx2/src/main/kotlin/com/dropbox/store/rx2/RxStore.kt
+++ b/store-rx2/src/main/kotlin/com/dropbox/store/rx2/RxStore.kt
@@ -9,7 +9,6 @@ import com.dropbox.android.external.store4.fresh
 import com.dropbox.android.external.store4.get
 import io.reactivex.Completable
 import io.reactivex.Flowable
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.rx2.asFlowable
 import kotlinx.coroutines.rx2.rxCompletable
 import kotlinx.coroutines.rx2.rxSingle
@@ -18,7 +17,6 @@ import kotlinx.coroutines.rx2.rxSingle
  * Return a [Flowable] for the given key
  * @param request - see [StoreRequest] for configurations
  */
-@ExperimentalCoroutinesApi
 fun <Key : Any, Output : Any> Store<Key, Output>.observe(request: StoreRequest<Key>): Flowable<StoreResponse<Output>> =
     stream(request).asFlowable()
 

--- a/store-rx2/src/main/kotlin/com/dropbox/store/rx2/RxStoreBuilder.kt
+++ b/store-rx2/src/main/kotlin/com/dropbox/store/rx2/RxStoreBuilder.kt
@@ -3,8 +3,6 @@ package com.dropbox.store.rx2
 import com.dropbox.android.external.store4.StoreBuilder
 import io.reactivex.Scheduler
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.rx2.asCoroutineDispatcher
 
@@ -12,8 +10,6 @@ import kotlinx.coroutines.rx2.asCoroutineDispatcher
  * Define what scheduler fetcher requests will be called on,
  * if a scheduler is not set Store will use [GlobalScope]
  */
-@FlowPreview
-@ExperimentalCoroutinesApi
 fun <Key : Any, Output : Any> StoreBuilder<Key, Output>.withScheduler(
     scheduler: Scheduler
 ): StoreBuilder<Key, Output> {

--- a/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/FlowTestExt.kt
+++ b/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/FlowTestExt.kt
@@ -19,19 +19,16 @@ import com.google.common.truth.FailureMetadata
 import com.google.common.truth.Subject
 import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertWithMessage
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.test.TestCoroutineScope
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal fun <T> TestCoroutineScope.assertThat(flow: Flow<T>): FlowSubject<T> {
     return Truth.assertAbout(FlowSubject.Factory<T>(this)).that(flow)
 }
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class FlowSubject<T> constructor(
     failureMetadata: FailureMetadata,
     private val testCoroutineScope: TestCoroutineScope,

--- a/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/HotRxSingleStoreTest.kt
+++ b/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/HotRxSingleStoreTest.kt
@@ -9,8 +9,6 @@ import com.dropbox.android.external.store4.StoreResponse
 import com.dropbox.store.rx2.ofResultSingle
 import com.google.common.truth.Truth.assertThat
 import io.reactivex.Single
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
@@ -18,8 +16,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-@FlowPreview
-@ExperimentalCoroutinesApi
 class HotRxSingleStoreTest {
     private val testScope = TestCoroutineScope()
 

--- a/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/RxFlowableStoreTest.kt
+++ b/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/RxFlowableStoreTest.kt
@@ -15,16 +15,12 @@ import io.reactivex.BackpressureStrategy
 import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.schedulers.TestScheduler
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import java.util.concurrent.atomic.AtomicInteger
 
 @RunWith(JUnit4::class)
-@FlowPreview
-@ExperimentalCoroutinesApi
 class RxFlowableStoreTest {
     private val testScheduler = TestScheduler()
     private val atomicInteger = AtomicInteger(0)

--- a/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/RxSingleStoreExtensionsTest.kt
+++ b/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/RxSingleStoreExtensionsTest.kt
@@ -6,16 +6,14 @@ import com.dropbox.android.external.store4.FetcherResult
 import com.dropbox.android.external.store4.SourceOfTruth
 import com.dropbox.android.external.store4.StoreBuilder
 import com.dropbox.store.rx2.freshSingle
-import com.dropbox.store.rx2.ofMaybe
 import com.dropbox.store.rx2.getSingle
+import com.dropbox.store.rx2.ofMaybe
 import com.dropbox.store.rx2.ofResultSingle
 import com.dropbox.store.rx2.withScheduler
 import io.reactivex.Completable
 import io.reactivex.Maybe
 import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -23,8 +21,6 @@ import java.util.concurrent.atomic.AtomicInteger
 
 @ExperimentalStoreApi
 @RunWith(JUnit4::class)
-@FlowPreview
-@ExperimentalCoroutinesApi
 class RxSingleStoreExtensionsTest {
     private val atomicInteger = AtomicInteger(0)
     private var fakeDisk = mutableMapOf<Int, String>()

--- a/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/RxSingleStoreTest.kt
+++ b/store-rx2/src/test/kotlin/com/dropbox/store/rx2/test/RxSingleStoreTest.kt
@@ -4,22 +4,20 @@ import com.dropbox.android.external.store4.ExperimentalStoreApi
 import com.dropbox.android.external.store4.Fetcher
 import com.dropbox.android.external.store4.FetcherResult
 import com.dropbox.android.external.store4.ResponseOrigin
+import com.dropbox.android.external.store4.SourceOfTruth
 import com.dropbox.android.external.store4.StoreBuilder
 import com.dropbox.android.external.store4.StoreRequest
 import com.dropbox.android.external.store4.StoreResponse
-import com.dropbox.android.external.store4.SourceOfTruth
-import com.dropbox.store.rx2.ofMaybe
 import com.dropbox.store.rx2.observe
 import com.dropbox.store.rx2.observeClear
 import com.dropbox.store.rx2.observeClearAll
+import com.dropbox.store.rx2.ofMaybe
 import com.dropbox.store.rx2.ofResultSingle
 import com.dropbox.store.rx2.withScheduler
 import io.reactivex.Completable
 import io.reactivex.Maybe
 import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -27,8 +25,6 @@ import java.util.concurrent.atomic.AtomicInteger
 
 @ExperimentalStoreApi
 @RunWith(JUnit4::class)
-@FlowPreview
-@ExperimentalCoroutinesApi
 class RxSingleStoreTest {
     private val atomicInteger = AtomicInteger(0)
     private var fakeDisk = mutableMapOf<Int, String>()

--- a/store-rx3/src/main/kotlin/com/dropbox/store/rx3/RxStore.kt
+++ b/store-rx3/src/main/kotlin/com/dropbox/store/rx3/RxStore.kt
@@ -9,7 +9,6 @@ import com.dropbox.android.external.store4.fresh
 import com.dropbox.android.external.store4.get
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Flowable
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.rx3.asFlowable
 import kotlinx.coroutines.rx3.rxCompletable
 import kotlinx.coroutines.rx3.rxSingle
@@ -18,7 +17,6 @@ import kotlinx.coroutines.rx3.rxSingle
  * Return a [Flowable] for the given key
  * @param request - see [StoreRequest] for configurations
  */
-@ExperimentalCoroutinesApi
 fun <Key : Any, Output : Any> Store<Key, Output>.observe(request: StoreRequest<Key>): Flowable<StoreResponse<Output>> =
     stream(request).asFlowable()
 

--- a/store-rx3/src/main/kotlin/com/dropbox/store/rx3/RxStoreBuilder.kt
+++ b/store-rx3/src/main/kotlin/com/dropbox/store/rx3/RxStoreBuilder.kt
@@ -3,8 +3,6 @@ package com.dropbox.store.rx3
 import com.dropbox.android.external.store4.StoreBuilder
 import io.reactivex.rxjava3.core.Scheduler
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.rx3.asCoroutineDispatcher
 
@@ -12,8 +10,6 @@ import kotlinx.coroutines.rx3.asCoroutineDispatcher
  * Define what scheduler fetcher requests will be called on,
  * if a scheduler is not set Store will use [GlobalScope]
  */
-@FlowPreview
-@ExperimentalCoroutinesApi
 fun <Key : Any, Output : Any> StoreBuilder<Key, Output>.withScheduler(
     scheduler: Scheduler
 ): StoreBuilder<Key, Output> {

--- a/store-rx3/src/test/kotlin/com/dropbox/store/rx3/test/FlowTestExt.kt
+++ b/store-rx3/src/test/kotlin/com/dropbox/store/rx3/test/FlowTestExt.kt
@@ -19,14 +19,12 @@ import com.google.common.truth.FailureMetadata
 import com.google.common.truth.Subject
 import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertWithMessage
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.test.TestCoroutineScope
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal fun <T> TestCoroutineScope.assertThat(flow: Flow<T>): FlowSubject<T> {
     return Truth.assertAbout(
         FlowSubject.Factory<T>(
@@ -35,7 +33,6 @@ internal fun <T> TestCoroutineScope.assertThat(flow: Flow<T>): FlowSubject<T> {
     ).that(flow)
 }
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class FlowSubject<T> constructor(
     failureMetadata: FailureMetadata,
     private val testCoroutineScope: TestCoroutineScope,

--- a/store-rx3/src/test/kotlin/com/dropbox/store/rx3/test/HotRxSingleStoreTest.kt
+++ b/store-rx3/src/test/kotlin/com/dropbox/store/rx3/test/HotRxSingleStoreTest.kt
@@ -9,8 +9,6 @@ import com.dropbox.android.external.store4.StoreResponse
 import com.dropbox.store.rx3.ofResultSingle
 import com.google.common.truth.Truth.assertThat
 import io.reactivex.rxjava3.core.Single
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
@@ -18,8 +16,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-@FlowPreview
-@ExperimentalCoroutinesApi
 class HotRxSingleStoreTest {
     private val testScope = TestCoroutineScope()
 

--- a/store-rx3/src/test/kotlin/com/dropbox/store/rx3/test/RxFlowableStoreTest.kt
+++ b/store-rx3/src/test/kotlin/com/dropbox/store/rx3/test/RxFlowableStoreTest.kt
@@ -15,16 +15,12 @@ import io.reactivex.rxjava3.core.BackpressureStrategy
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.schedulers.TestScheduler
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import java.util.concurrent.atomic.AtomicInteger
 
 @RunWith(JUnit4::class)
-@FlowPreview
-@ExperimentalCoroutinesApi
 class RxFlowableStoreTest {
     private val testScheduler = TestScheduler()
     private val atomicInteger = AtomicInteger(0)

--- a/store-rx3/src/test/kotlin/com/dropbox/store/rx3/test/RxSingleStoreExtensionsTest.kt
+++ b/store-rx3/src/test/kotlin/com/dropbox/store/rx3/test/RxSingleStoreExtensionsTest.kt
@@ -6,16 +6,14 @@ import com.dropbox.android.external.store4.FetcherResult
 import com.dropbox.android.external.store4.SourceOfTruth
 import com.dropbox.android.external.store4.StoreBuilder
 import com.dropbox.store.rx3.freshSingle
-import com.dropbox.store.rx3.ofMaybe
 import com.dropbox.store.rx3.getSingle
+import com.dropbox.store.rx3.ofMaybe
 import com.dropbox.store.rx3.ofResultSingle
 import com.dropbox.store.rx3.withScheduler
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Maybe
 import io.reactivex.rxjava3.core.Single
 import io.reactivex.rxjava3.schedulers.Schedulers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -23,8 +21,6 @@ import java.util.concurrent.atomic.AtomicInteger
 
 @ExperimentalStoreApi
 @RunWith(JUnit4::class)
-@FlowPreview
-@ExperimentalCoroutinesApi
 class RxSingleStoreExtensionsTest {
     private val atomicInteger = AtomicInteger(0)
     private var fakeDisk = mutableMapOf<Int, String>()

--- a/store-rx3/src/test/kotlin/com/dropbox/store/rx3/test/RxSingleStoreTest.kt
+++ b/store-rx3/src/test/kotlin/com/dropbox/store/rx3/test/RxSingleStoreTest.kt
@@ -18,8 +18,6 @@ import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Maybe
 import io.reactivex.rxjava3.core.Single
 import io.reactivex.rxjava3.schedulers.Schedulers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -27,8 +25,6 @@ import java.util.concurrent.atomic.AtomicInteger
 
 @ExperimentalStoreApi
 @RunWith(JUnit4::class)
-@FlowPreview
-@ExperimentalCoroutinesApi
 class RxSingleStoreTest {
     private val atomicInteger = AtomicInteger(0)
     private var fakeDisk = mutableMapOf<Int, String>()

--- a/store/src/main/java/com/dropbox/android/external/store4/StoreBuilder.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/StoreBuilder.kt
@@ -17,16 +17,12 @@ package com.dropbox.android.external.store4
 
 import com.dropbox.android.external.store4.impl.RealStore
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.GlobalScope
 import kotlin.time.ExperimentalTime
 
 /**
  * Main entry point for creating a [Store].
  */
-@FlowPreview
-@ExperimentalCoroutinesApi
 interface StoreBuilder<Key : Any, Output : Any> {
     fun build(): Store<Key, Output>
 
@@ -59,7 +55,7 @@ interface StoreBuilder<Key : Any, Output : Any> {
          *
          * @param fetcher a [Fetcher] flow of network records.
          */
-        @OptIn(ExperimentalTime::class)
+        @ExperimentalTime
         fun <Key : Any, Output : Any> from(
             fetcher: Fetcher<Key, Output>
         ): StoreBuilder<Key, Output> = RealStoreBuilder(fetcher)
@@ -70,6 +66,7 @@ interface StoreBuilder<Key : Any, Output : Any> {
          * @param fetcher a function for fetching a flow of network records.
          * @param sourceOfTruth a [SourceOfTruth] for the store.
          */
+        @ExperimentalTime
         fun <Key : Any, Input : Any, Output : Any> from(
             fetcher: Fetcher<Key, Input>,
             sourceOfTruth: SourceOfTruth<Key, Input, Output>
@@ -80,9 +77,7 @@ interface StoreBuilder<Key : Any, Output : Any> {
     }
 }
 
-@FlowPreview
-@OptIn(ExperimentalTime::class)
-@ExperimentalCoroutinesApi
+@ExperimentalTime
 private class RealStoreBuilder<Key : Any, Input : Any, Output : Any>(
     private val fetcher: Fetcher<Key, Input>,
     private val sourceOfTruth: SourceOfTruth<Key, Input, Output>? = null

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/FetcherController.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/FetcherController.kt
@@ -22,8 +22,6 @@ import com.dropbox.android.external.store4.SourceOfTruth
 import com.dropbox.android.external.store4.StoreResponse
 import com.dropbox.flow.multicast.Multicaster
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
@@ -39,8 +37,6 @@ import kotlinx.coroutines.flow.onEmpty
  * fetcher requests receives values dispatched by later requests even if they don't share the
  * request.
  */
-@FlowPreview
-@ExperimentalCoroutinesApi
 internal class FetcherController<Key : Any, Input : Any, Output : Any>(
     /**
      * The [CoroutineScope] to use when collecting from the fetcher

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
@@ -29,8 +29,6 @@ import com.dropbox.android.external.store4.impl.operators.merge
 import com.nytimes.android.external.cache3.CacheBuilder
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
@@ -41,8 +39,6 @@ import java.util.concurrent.TimeUnit
 import kotlin.time.ExperimentalTime
 
 @ExperimentalTime
-@ExperimentalCoroutinesApi
-@FlowPreview
 internal class RealStore<Key : Any, Input : Any, Output : Any>(
     scope: CoroutineScope,
     fetcher: Fetcher<Key, Input>,

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/SourceOfTruthWithBarrier.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/SourceOfTruthWithBarrier.kt
@@ -21,7 +21,6 @@ import com.dropbox.android.external.store4.StoreResponse
 import com.dropbox.android.external.store4.impl.operators.mapIndexed
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
@@ -38,7 +37,6 @@ import java.util.concurrent.atomic.AtomicLong
  * Used in the [com.dropbox.android.external.store4.impl.RealStore] implementation to avoid
  * dispatching values to downstream while a write is in progress.
  */
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class SourceOfTruthWithBarrier<Key, Input, Output>(
     private val delegate: SourceOfTruth<Key, Input, Output>
 ) {

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/operators/FlowMerge.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/operators/FlowMerge.kt
@@ -15,7 +15,6 @@
  */
 package com.dropbox.android.external.store4.impl.operators
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.buffer
@@ -26,7 +25,6 @@ import kotlinx.coroutines.launch
 /**
  * Merge implementation tells downstream what the source is and also uses a rendezvous channel
  */
-@ExperimentalCoroutinesApi
 internal fun <T, R> Flow<T>.merge(other: Flow<R>): Flow<Either<T, R>> {
     return channelFlow<Either<T, R>> {
         launch {

--- a/store/src/test/java/com/dropbox/android/external/store3/DontCacheErrorsTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/DontCacheErrorsTest.kt
@@ -1,19 +1,16 @@
 package com.dropbox.android.external.store3
 
-import com.dropbox.android.external.store4.get
 import com.dropbox.android.external.store4.Fetcher
-
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
+import com.dropbox.android.external.store4.get
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
+import kotlin.time.ExperimentalTime
 
-@FlowPreview
-@ExperimentalCoroutinesApi
+@ExperimentalTime
 @RunWith(Parameterized::class)
 class DontCacheErrorsTest(
     storeType: TestStoreType

--- a/store/src/test/java/com/dropbox/android/external/store3/NoNetworkTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/NoNetworkTest.kt
@@ -4,8 +4,6 @@ import com.dropbox.android.external.store4.Fetcher
 import com.dropbox.android.external.store4.Store
 import com.dropbox.android.external.store4.get
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.fail
@@ -13,8 +11,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
-@FlowPreview
-@ExperimentalCoroutinesApi
 @RunWith(Parameterized::class)
 class NoNetworkTest(
     storeType: TestStoreType

--- a/store/src/test/java/com/dropbox/android/external/store3/SequentialTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/SequentialTest.kt
@@ -3,17 +3,15 @@ package com.dropbox.android.external.store3
 import com.dropbox.android.external.store4.Fetcher
 import com.dropbox.android.external.store4.get
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
+import kotlin.time.ExperimentalTime
 
-@FlowPreview
-@ExperimentalCoroutinesApi
+@ExperimentalTime
 @RunWith(Parameterized::class)
 class SequentialTest(
     storeType: TestStoreType

--- a/store/src/test/java/com/dropbox/android/external/store3/StoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/StoreTest.kt
@@ -13,8 +13,6 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestCoroutineScope
@@ -28,8 +26,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.ExperimentalTime
 
 @ExperimentalTime
-@FlowPreview
-@ExperimentalCoroutinesApi
 @RunWith(Parameterized::class)
 class StoreTest(
     private val storeType: TestStoreType

--- a/store/src/test/java/com/dropbox/android/external/store3/StoreThrowOnNoItems.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/StoreThrowOnNoItems.kt
@@ -4,8 +4,6 @@ import com.dropbox.android.external.store4.Fetcher
 import com.dropbox.android.external.store4.get
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import com.google.common.truth.Truth.assertThat
@@ -14,9 +12,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.ExperimentalTime
 
-@FlowPreview
-@ExperimentalCoroutinesApi
+@ExperimentalTime
 @RunWith(Parameterized::class)
 class StoreThrowOnNoItems(
     private val storeType: TestStoreType

--- a/store/src/test/java/com/dropbox/android/external/store3/StreamOneKeyTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/StreamOneKeyTest.kt
@@ -8,8 +8,6 @@ import com.dropbox.android.external.store4.testutil.FakeFetcher
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.test.TestCoroutineScope
@@ -19,8 +17,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
-@FlowPreview
-@ExperimentalCoroutinesApi
 @RunWith(Parameterized::class)
 class StreamOneKeyTest(
     storeType: TestStoreType

--- a/store/src/test/java/com/dropbox/android/external/store3/TestStoreBuilder.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/TestStoreBuilder.kt
@@ -22,13 +22,9 @@ import com.dropbox.android.external.store4.Store
 import com.dropbox.android.external.store4.StoreBuilder
 import com.dropbox.android.external.store4.impl.PersistentSourceOfTruth
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.flow
 import kotlin.time.ExperimentalTime
 
-@FlowPreview
-@ExperimentalCoroutinesApi
 data class TestStoreBuilder<Key : Any, Output : Any>(
     private val buildStore: () -> Store<Key, Output>
 ) {

--- a/store/src/test/java/com/dropbox/android/external/store4/FetcherControllerTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/FetcherControllerTest.kt
@@ -18,8 +18,6 @@ package com.dropbox.android.external.store4
 import com.dropbox.android.external.store4.StoreResponse.Data
 import com.dropbox.android.external.store4.impl.FetcherController
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
@@ -31,8 +29,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-@ExperimentalCoroutinesApi
-@FlowPreview
 @RunWith(JUnit4::class)
 class FetcherControllerTest {
     private val testScope = TestCoroutineScope()

--- a/store/src/test/java/com/dropbox/android/external/store4/SourceOfTruthErrorsTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/SourceOfTruthErrorsTest.kt
@@ -21,7 +21,6 @@ import com.dropbox.android.external.store4.testutil.FakeFetcher
 import com.dropbox.android.external.store4.testutil.InMemoryPersister
 import com.dropbox.android.external.store4.testutil.asSourceOfTruth
 import com.dropbox.android.external.store4.testutil.assertThat
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
@@ -33,8 +32,9 @@ import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import kotlin.time.ExperimentalTime
 
-@FlowPreview
+@ExperimentalTime
 @RunWith(JUnit4::class)
 class SourceOfTruthErrorsTest {
     private val testScope = TestCoroutineScope()

--- a/store/src/test/java/com/dropbox/android/external/store4/SourceOfTruthWithBarrierTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/SourceOfTruthWithBarrierTest.kt
@@ -23,8 +23,6 @@ import com.dropbox.android.external.store4.testutil.InMemoryPersister
 import com.dropbox.android.external.store4.testutil.assertThat
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.collect
@@ -35,8 +33,6 @@ import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 
-@FlowPreview
-@ExperimentalCoroutinesApi
 class SourceOfTruthWithBarrierTest {
     private val testScope = TestCoroutineScope()
     private val persister = InMemoryPersister<Int, String>()

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/ClearAllStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/ClearAllStoreTest.kt
@@ -9,16 +9,12 @@ import com.dropbox.android.external.store4.testutil.InMemoryPersister
 import com.dropbox.android.external.store4.testutil.asSourceOfTruth
 import com.dropbox.android.external.store4.testutil.getData
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-@FlowPreview
-@ExperimentalCoroutinesApi
 @ExperimentalStoreApi
 @RunWith(JUnit4::class)
 class ClearAllStoreTest {

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/ClearStoreByKeyTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/ClearStoreByKeyTest.kt
@@ -8,16 +8,12 @@ import com.dropbox.android.external.store4.testutil.InMemoryPersister
 import com.dropbox.android.external.store4.testutil.asSourceOfTruth
 import com.dropbox.android.external.store4.testutil.getData
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-@FlowPreview
-@ExperimentalCoroutinesApi
 @RunWith(JUnit4::class)
 class ClearStoreByKeyTest {
 

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FetcherResponseTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FetcherResponseTest.kt
@@ -8,8 +8,6 @@ import com.dropbox.android.external.store4.StoreRequest
 import com.dropbox.android.external.store4.StoreResponse
 import com.dropbox.android.external.store4.testutil.assertThat
 import com.google.common.truth.Truth
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
@@ -17,8 +15,6 @@ import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 
-@ExperimentalCoroutinesApi
-@FlowPreview
 class FetcherResponseTest {
     private val testScope = TestCoroutineScope()
 

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/FlowStoreTest.kt
@@ -31,8 +31,6 @@ import com.dropbox.android.external.store4.testutil.asFlowable
 import com.dropbox.android.external.store4.testutil.asSourceOfTruth
 import com.dropbox.android.external.store4.testutil.assertThat
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
@@ -48,8 +46,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-@FlowPreview
-@ExperimentalCoroutinesApi
 @RunWith(JUnit4::class)
 class FlowStoreTest {
     private val testScope = TestCoroutineScope()

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/HotFlowStoreTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/HotFlowStoreTest.kt
@@ -8,8 +8,6 @@ import com.dropbox.android.external.store4.StoreRequest
 import com.dropbox.android.external.store4.StoreResponse
 import com.dropbox.android.external.store4.testutil.assertThat
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestCoroutineScope
@@ -18,8 +16,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-@ExperimentalCoroutinesApi
-@FlowPreview
 @RunWith(JUnit4::class)
 class HotFlowStoreTest {
     private val testScope = TestCoroutineScope()

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/KeyTrackerTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/KeyTrackerTest.kt
@@ -17,7 +17,6 @@ package com.dropbox.android.external.store4.impl
 
 import com.dropbox.android.external.store4.testutil.KeyTracker
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.take
@@ -29,7 +28,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-@ExperimentalCoroutinesApi
 @RunWith(JUnit4::class)
 class KeyTrackerTest {
     private val scope1 = TestCoroutineScope()

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/StoreWithInMemoryCacheTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/StoreWithInMemoryCacheTest.kt
@@ -4,8 +4,6 @@ import com.dropbox.android.external.store4.Fetcher
 import com.dropbox.android.external.store4.MemoryPolicy
 import com.dropbox.android.external.store4.StoreBuilder
 import com.dropbox.android.external.store4.get
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,9 +11,7 @@ import org.junit.runners.JUnit4
 import kotlin.time.ExperimentalTime
 import kotlin.time.minutes
 
-@FlowPreview
 @ExperimentalTime
-@ExperimentalCoroutinesApi
 @RunWith(JUnit4::class)
 class StoreWithInMemoryCacheTest {
 

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/StreamWithoutSourceOfTruthTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/StreamWithoutSourceOfTruthTest.kt
@@ -22,8 +22,6 @@ import com.dropbox.android.external.store4.StoreResponse
 import com.dropbox.android.external.store4.testutil.FakeFetcher
 import com.dropbox.android.external.store4.testutil.assertThat
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.take
@@ -34,8 +32,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
-@FlowPreview
-@ExperimentalCoroutinesApi
 @RunWith(Parameterized::class)
 class StreamWithoutSourceOfTruthTest(
     private val enableCache: Boolean

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/ValueFetcherTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/ValueFetcherTest.kt
@@ -3,16 +3,12 @@ package com.dropbox.android.external.store4.impl
 import com.dropbox.android.external.store4.Fetcher
 import com.dropbox.android.external.store4.FetcherResult
 import com.dropbox.android.external.store4.testutil.assertThat
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 
-@ExperimentalCoroutinesApi
-@FlowPreview
 class ValueFetcherTest {
 
     private val testScope = TestCoroutineScope()

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/operators/MapIndexedKtTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/operators/MapIndexedKtTest.kt
@@ -1,13 +1,11 @@
 package com.dropbox.android.external.store4.impl.operators
 
 import com.dropbox.android.external.store4.testutil.assertThat
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class MapIndexedKtTest {
     val scope = TestCoroutineScope()
     @Test

--- a/store/src/test/java/com/dropbox/android/external/store4/testutil/FlowSubjectTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/testutil/FlowSubjectTest.kt
@@ -17,7 +17,6 @@
 package com.dropbox.android.external.store4.testutil
 
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -29,7 +28,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class FlowSubjectTest {
     // Can't use ExpectFailure in these tests because it is not a suspend function.
     private val testScope = TestCoroutineScope()

--- a/store/src/test/java/com/dropbox/android/external/store4/testutil/FlowTestExt.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/testutil/FlowTestExt.kt
@@ -19,19 +19,16 @@ import com.google.common.truth.FailureMetadata
 import com.google.common.truth.Subject
 import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertWithMessage
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.test.TestCoroutineScope
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal fun <T> TestCoroutineScope.assertThat(flow: Flow<T>): FlowSubject<T> {
     return Truth.assertAbout(FlowSubject.Factory<T>(this)).that(flow)
 }
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class FlowSubject<T> constructor(
     failureMetadata: FailureMetadata,
     private val testCoroutineScope: TestCoroutineScope,

--- a/store/src/test/java/com/dropbox/android/external/store4/testutil/SimplePersisterAsFlowable.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/testutil/SimplePersisterAsFlowable.kt
@@ -16,7 +16,6 @@
 package com.dropbox.android.external.store4.testutil
 
 import com.dropbox.android.external.store4.SourceOfTruth
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -29,7 +28,6 @@ import kotlinx.coroutines.sync.withLock
 /**
  * Only used in FlowStoreTest. We should get rid of it eventually.
  */
-@ExperimentalCoroutinesApi
 class SimplePersisterAsFlowable<Key, Input, Output>(
     private val reader: suspend (Key) -> Output?,
     private val writer: suspend (Key, Input) -> Unit,
@@ -60,7 +58,6 @@ class SimplePersisterAsFlowable<Key, Input, Output>(
     }
 }
 
-@ExperimentalCoroutinesApi
 fun <Key : Any, Input : Any, Output : Any> SimplePersisterAsFlowable<Key, Input, Output>.asSourceOfTruth() =
     SourceOfTruth.of(
         reader = ::flowReader,
@@ -71,7 +68,6 @@ fun <Key : Any, Input : Any, Output : Any> SimplePersisterAsFlowable<Key, Input,
 /**
  * helper class which provides Flows for Keys that can be tracked.
  */
-@ExperimentalCoroutinesApi
 internal class KeyTracker<Key> {
     private val lock = Mutex()
     // list of open key channels
@@ -144,7 +140,6 @@ internal class KeyTracker<Key> {
     }
 }
 
-@ExperimentalCoroutinesApi
 fun <Key : Any, Output : Any> InMemoryPersister<Key, Output>.asFlowable() =
     SimplePersisterAsFlowable(
         reader = this::read,

--- a/store/src/test/java/com/dropbox/android/external/store4/testutil/SimplePersisterAsFlowableTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/testutil/SimplePersisterAsFlowableTest.kt
@@ -17,7 +17,6 @@ package com.dropbox.android.external.store4.testutil
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
@@ -28,7 +27,6 @@ import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 
-@ExperimentalCoroutinesApi
 class SimplePersisterAsFlowableTest {
     private val testScope = TestCoroutineScope()
     private val otherScope = TestCoroutineScope()


### PR DESCRIPTION
# In newer versions of Kotlin, these are no longer experimental.  Annotations are no longer required since Flow has been stable since 1.4 and now we are on 1.5.
* Removes: `@ExperimentalCoroutinesApi` and `@FlowPreview` references.
* Some additional usage of `@ExperimentalTime` where required.

---
This relates to some work done in #166 where some of the annotations were removed.