### PR TITLE
Fix RxBuilder scheduler comment

### DIFF
--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -26,7 +26,7 @@ ext.versions = [
         retrofit          : '2.9.0',
         jsr305            : '3.0.2',
         okHttp            : '4.6.0',
-        okio              : '2.6.0',
+        okio              : '2.10.0',
         moshi             : '1.12.0',
         appCompat         : '1.3.1',
         fragment          : '1.3.6',

--- a/store-rx2/src/main/kotlin/com/dropbox/store/rx2/RxStoreBuilder.kt
+++ b/store-rx2/src/main/kotlin/com/dropbox/store/rx2/RxStoreBuilder.kt
@@ -1,5 +1,6 @@
 package com.dropbox.store.rx2
 
+import com.dropbox.android.external.store4.Store
 import com.dropbox.android.external.store4.StoreBuilder
 import io.reactivex.Scheduler
 import kotlinx.coroutines.CoroutineScope
@@ -7,8 +8,16 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.rx2.asCoroutineDispatcher
 
 /**
- * Define what scheduler fetcher requests will be called on,
- * if a scheduler is not set Store will use [GlobalScope]
+ *  A store multicasts same [Output] value to many consumers (Similar to RxJava.share()), by default
+ *  [Store] will open a global scope for management of shared responses, if instead you'd like to control
+ *  the scheduler that sharing/multicasting happens in you can pass a @param [scheduler]
+ *
+ *  Note this does not control what scheduler a response is emitted on but rather what thread/scheduler
+ *  to use when managing in flight responses. This is usually used for things like testing where you
+ *  may want to confine to a scheduler backed by a single thread executor
+ *
+ *   @param scheduler - scheduler to use for sharing
+ *  if a scheduler is not set Store will use [GlobalScope]
  */
 fun <Key : Any, Output : Any> StoreBuilder<Key, Output>.withScheduler(
     scheduler: Scheduler

--- a/store-rx3/src/main/kotlin/com/dropbox/store/rx3/RxStoreBuilder.kt
+++ b/store-rx3/src/main/kotlin/com/dropbox/store/rx3/RxStoreBuilder.kt
@@ -1,5 +1,6 @@
 package com.dropbox.store.rx3
 
+import com.dropbox.android.external.store4.Store
 import com.dropbox.android.external.store4.StoreBuilder
 import io.reactivex.rxjava3.core.Scheduler
 import kotlinx.coroutines.CoroutineScope
@@ -7,8 +8,16 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.rx3.asCoroutineDispatcher
 
 /**
- * Define what scheduler fetcher requests will be called on,
- * if a scheduler is not set Store will use [GlobalScope]
+ *  A store multicasts same [Output] value to many consumers (Similar to RxJava.share()), by default
+ *  [Store] will open a global scope for management of shared responses, if instead you'd like to control
+ *  the scheduler that sharing/multicasting happens in you can pass a @param [scheduler]
+ *
+ *  Note this does not control what scheduler a response is emitted on but rather what thread/scheduler
+ *  to use when managing in flight responses. This is usually used for things like testing where you
+ *  may want to confine to a scheduler backed by a single thread executor
+ *
+ *   @param scheduler - scheduler to use for sharing
+ *  if a scheduler is not set Store will use [GlobalScope]
  */
 fun <Key : Any, Output : Any> StoreBuilder<Key, Output>.withScheduler(
     scheduler: Scheduler


### PR DESCRIPTION
closes https://github.com/dropbox/Store/issues/207 by making comment align with the non rx store

