### PR TITLE
Automatically prepare next development version

### DIFF
--- a/.github/workflows/.ci_test_and_publish.yml
+++ b/.github/workflows/.ci_test_and_publish.yml
@@ -41,6 +41,21 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
+          
+      - name: Prepare next development version
+        run: |
+          sed -i -e "s/${VERSION_NAME}/${VERSION_NAME}-SNAPSHOT/g" gradle.properties
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -m "Prepare next development version" -a
+        if: "!endsWith(env.VERSION_NAME, '-SNAPSHOT')"
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+        if: "!endsWith(env.VERSION_NAME, '-SNAPSHOT')"          
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Please see our contributing guidelines (contributing.md) primarily make sure to sign our cla as we cannot accept code externally without a signed cla

https://opensource.dropbox.com/cla/
