### PR TITLE
README fix - MemoryPolicy updates from PR #200

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,14 +225,14 @@ StoreBuilder
             deleteAll = db.postDao()::clearAllFeeds
         )
     ).cachePolicy(
-        MemoryPolicy.builder()
-            .setMemorySize(10)
+        MemoryPolicy.builder<Any, Any>()
+            .setMaxSize(10)
             .setExpireAfterAccess(10.minutes) // or setExpireAfterWrite(10.minutes)
             .build()
     ).build()
 ```
 
-* `setMemorySize(maxSize: Long)` sets the maximum number of entries to be kept in the cache before starting to evict the least recently used items.
+* `setMaxSize(maxSize: Long)` sets the maximum number of entries to be kept in the cache before starting to evict the least recently used items.
 * `setExpireAfterAccess(expireAfterAccess: Duration)` sets the maximum time an entry can live in the cache since the last access, where "access" means reading the cache, adding a new cache entry, and replacing an existing entry with a new one. This duration is also known as **time-to-idle (TTI)**.
 * `setExpireAfterWrite(expireAfterWrite: Duration)` sets the maximum time an entry can live in the cache since the last write, where "write" means adding a new cache entry and replacing an existing entry with a new one. This duration is also known as **time-to-live (TTL)**.
 


### PR DESCRIPTION
Going through the README I found that the provided code example no longer compiled due to changes made in #200. Could be confusing for newcomers.

`setMemorySize` -> `setMaxSize` rename and new `<in Key : Any, in Value : Any>` generics on `MemoryPolicy`.

