### PR TITLE
Version Bumps - AGP 7.1.2, Kotlin 1.6.10 and related updates

### DIFF
--- a/.github/workflows/.ci_test_and_publish.yml
+++ b/.github/workflows/.ci_test_and_publish.yml
@@ -65,7 +65,7 @@ jobs:
       uses: reactivecircus/android-emulator-runner@v2
       with:
             api-level: 29
-            script: ./gradlew clean cleanBuildCache check --stacktrace
+            script: ./gradlew check --rerun-tasks --stacktrace
       env:
         API_LEVEL: ${{ matrix.api-level }}
     - name: Upload code coverage

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ allprojects {
 }
 
 subprojects {
-    apply plugin: 'com.diffplug.gradle.spotless'
+    apply plugin: 'com.diffplug.spotless'
     spotless {
         kotlin {
             target 'src/**/*.kt'

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -2,7 +2,7 @@ ext.versions = [
         minSdk                      : 16,
         targetSdk                   : 29,
         compileSdk                  : 31,
-        buildTools                  : '29.0.3',
+        buildTools                  : '30.0.3',
         kotlin                      : '1.6.10',
         ktlint                      : '0.39.0',
 

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -13,7 +13,7 @@ ext.versions = [
         spotlessGradlePlugin        : '3.26.1',
         jacocoGradlePlugin          : '0.8.7',
         binaryCompatibilityValidator: '0.4.0',
-        atomicFuPlugin              : '0.14.2',
+        atomicFuPlugin              : '0.14.4',
         mavenPublishPlugin          : "0.18.0",
 
         cache                       : '3.1.1',

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -7,7 +7,7 @@ ext.versions = [
         ktlint                      : '0.39.0',
 
         // Plugins
-        androidGradlePlugin         : '7.0.2',
+        androidGradlePlugin         : '7.1.2',
         dokkaGradlePlugin           : '1.6.0',
         ktlintGradle                : '10.2.1',
         spotlessGradlePlugin        : '3.26.1',

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -13,7 +13,7 @@ ext.versions = [
         spotlessGradlePlugin        : '3.26.1',
         jacocoGradlePlugin          : '0.8.7',
         binaryCompatibilityValidator: '0.4.0',
-        atomicFuPlugin              : '0.15.0',
+        atomicFuPlugin              : '0.15.1',
         mavenPublishPlugin          : "0.18.0",
 
         cache                       : '3.1.1',

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -12,7 +12,7 @@ ext.versions = [
         ktlintGradle                : '10.2.1',
         spotlessGradlePlugin        : '3.26.1',
         jacocoGradlePlugin          : '0.8.7',
-        binaryCompatibilityValidator: '0.2.3',
+        binaryCompatibilityValidator: '0.4.0',
         atomicFuPlugin              : '0.14.2',
         mavenPublishPlugin          : "0.18.0",
 

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -13,7 +13,7 @@ ext.versions = [
         spotlessGradlePlugin        : '3.26.1',
         jacocoGradlePlugin          : '0.8.7',
         binaryCompatibilityValidator: '0.4.0',
-        atomicFuPlugin              : '0.14.4',
+        atomicFuPlugin              : '0.15.0',
         mavenPublishPlugin          : "0.18.0",
 
         cache                       : '3.1.1',

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -7,7 +7,7 @@ ext.versions = [
         ktlint                      : '0.39.0',
 
         // Plugins
-        androidGradlePlugin         : '4.2.0',
+        androidGradlePlugin         : '7.0.2',
         dokkaGradlePlugin           : '1.6.0',
         ktlintGradle                : '10.2.1',
         spotlessGradlePlugin        : '3.26.1',

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -3,14 +3,14 @@ ext.versions = [
         targetSdk                   : 29,
         compileSdk                  : 31,
         buildTools                  : '29.0.3',
-        kotlin                      : '1.5.31',
+        kotlin                      : '1.6.10',
         ktlint                      : '0.39.0',
 
         // Plugins
         androidGradlePlugin         : '7.1.2',
         dokkaGradlePlugin           : '1.6.0',
         ktlintGradle                : '10.2.1',
-        spotlessGradlePlugin        : '3.26.1',
+        spotlessGradlePlugin        : '6.3.0',
         jacocoGradlePlugin          : '0.8.7',
         binaryCompatibilityValidator: '0.4.0',
         atomicFuPlugin              : '0.15.1',

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -7,7 +7,7 @@ ext.versions = [
         ktlint                      : '0.39.0',
 
         // Plugins
-        androidGradlePlugin         : '4.1.0',
+        androidGradlePlugin         : '4.2.0',
         dokkaGradlePlugin           : '1.6.0',
         ktlintGradle                : '10.2.1',
         spotlessGradlePlugin        : '3.26.1',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip

--- a/store/src/test/java/com/dropbox/android/external/store3/DontCacheErrorsTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/DontCacheErrorsTest.kt
@@ -2,6 +2,7 @@ package com.dropbox.android.external.store3
 
 import com.dropbox.android.external.store4.get
 import com.dropbox.android.external.store4.Fetcher
+import kotlin.time.ExperimentalTime
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -22,6 +23,7 @@ class DontCacheErrorsTest(
     private var shouldThrow: Boolean = false
 
     // TODO move to test coroutine scope
+    @OptIn(ExperimentalTime::class)
     private val store = TestStoreBuilder.from<Pair<String, String>, Int>(
         testScope,
         fetcher = Fetcher.of {

--- a/store/src/test/java/com/dropbox/android/external/store3/NoNetworkTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/NoNetworkTest.kt
@@ -4,6 +4,7 @@ import com.dropbox.android.external.store4.Fetcher
 import com.dropbox.android.external.store4.Store
 import com.dropbox.android.external.store4.get
 import com.google.common.truth.Truth.assertThat
+import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.test.TestCoroutineScope
@@ -20,6 +21,8 @@ class NoNetworkTest(
     storeType: TestStoreType
 ) {
     private val testScope = TestCoroutineScope()
+    
+    @OptIn(ExperimentalTime::class)
     private val store: Store<Pair<String, String>, out Any> = TestStoreBuilder.from<Pair<String, String>, Any>(
         testScope,
         fetcher = Fetcher.of {

--- a/store/src/test/java/com/dropbox/android/external/store3/NoNetworkTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/NoNetworkTest.kt
@@ -21,7 +21,7 @@ class NoNetworkTest(
     storeType: TestStoreType
 ) {
     private val testScope = TestCoroutineScope()
-    
+
     @OptIn(ExperimentalTime::class)
     private val store: Store<Pair<String, String>, out Any> = TestStoreBuilder.from<Pair<String, String>, Any>(
         testScope,

--- a/store/src/test/java/com/dropbox/android/external/store3/SequentialTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/SequentialTest.kt
@@ -3,6 +3,7 @@ package com.dropbox.android.external.store3
 import com.dropbox.android.external.store4.Fetcher
 import com.dropbox.android.external.store4.get
 import com.google.common.truth.Truth.assertThat
+import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
@@ -21,6 +22,8 @@ class SequentialTest(
     private val testScope = TestCoroutineScope()
 
     var networkCalls = 0
+
+    @OptIn(ExperimentalTime::class)
     private val store = TestStoreBuilder.from<Pair<String, String>, Int>(
         scope = testScope,
         cached = true,

--- a/store/src/test/java/com/dropbox/android/external/store3/StreamOneKeyTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store3/StreamOneKeyTest.kt
@@ -8,6 +8,7 @@ import com.dropbox.android.external.store4.testutil.FakeFetcher
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
+import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.stateIn
@@ -38,6 +39,7 @@ class StreamOneKeyTest(
         barCode2 to TEST_ITEM
     )
 
+    @OptIn(ExperimentalTime::class)
     private val store = TestStoreBuilder.from(
         scope = testScope,
         fetcher = fetcher,


### PR DESCRIPTION
I'm working my way to a Kotlin 1.6.10 upgrade.  These are safe version bumps to get us closer, but there are issues when bumping to higher versions of binary-compatibility-validator or the Kotlin Atomic FU plugin.  This gets us closer though so we can figure out the remaining issues to get to Kotlin 1.6.10

* AGP 4.1.0 -> 7.1.2
* Gradle Wrapper 6.9.2 -> 7.4.1
* Binary Compatibility Validator 0.2.3 -> 0.4.0
* Atomic Plugin 0.14.2 -> 0.15.1
* Kotlin 1.5.31 -> 1.6.10
* Android Build Tools 29.0.3 -> 30.0.3
* Spotless Plugin 3.26.1 -> 6.3.0