### PR TITLE
Bumping CI to Java 11

### DIFF
--- a/.github/workflows/.ci_test_and_publish.yml
+++ b/.github/workflows/.ci_test_and_publish.yml
@@ -57,9 +57,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up our JDK environment
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        distribution: zulu
+        java-version: 11
     - name: Run tests
       uses: reactivecircus/android-emulator-runner@v2
       with:


### PR DESCRIPTION
I wanted to see if we could pull this out into it's own PR instead of including in the larger version bumps PR: https://github.com/dropbox/Store/pull/414