### PR TITLE
Remove Kotlin Android Extensions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'kotlin-kapt'
-    id 'kotlin-android-extensions'
     id 'org.jetbrains.kotlin.plugin.serialization'
 }
 

--- a/app/src/main/java/com/dropbox/android/sample/MainActivity.kt
+++ b/app/src/main/java/com/dropbox/android/sample/MainActivity.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
-import kotlinx.android.synthetic.main.activity_main.*
+import com.google.android.material.bottomnavigation.BottomNavigationView
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -15,6 +15,6 @@ class MainActivity : AppCompatActivity() {
         val navController = navHostFragment.navController
 
         // Setup bottom navigation with navigation controller
-        bottomNavigationView.setupWithNavController(navController)
+        findViewById<BottomNavigationView>(R.id.bottomNavigationView).setupWithNavController(navController)
     }
 }

--- a/app/src/main/java/com/dropbox/android/sample/reddit/PostViewHolder.kt
+++ b/app/src/main/java/com/dropbox/android/sample/reddit/PostViewHolder.kt
@@ -1,19 +1,24 @@
 package com.dropbox.android.sample.reddit
 
 import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import com.dropbox.android.sample.R
 import com.dropbox.android.sample.data.model.Post
 import com.squareup.picasso.Picasso
-import kotlinx.android.synthetic.main.article_item.view.*
 
 class PostViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
 
+    private val title: TextView get() = itemView.findViewById(R.id.title)
+
+    private val thumbnail: ImageView get() = itemView.findViewById(R.id.thumbnail)
+
     fun onBind(article: Post) {
-        itemView.title!!.text = article.title
+        title.text = article.title
         val url = article.nestedThumbnail()?.url
-        itemView.thumbnail.isVisible = url != null
+        thumbnail.isVisible = url != null
         url?.let { showImage(it) }
     }
 
@@ -21,6 +26,6 @@ class PostViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         Picasso.with(itemView.context)
             .load(url)
             .placeholder(R.color.gray80)
-            .into(itemView.thumbnail)
+            .into(thumbnail)
     }
 }

--- a/app/src/main/java/com/dropbox/android/sample/ui/reddit/RedditFragment.kt
+++ b/app/src/main/java/com/dropbox/android/sample/ui/reddit/RedditFragment.kt
@@ -4,22 +4,35 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.EditText
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
+import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.dropbox.android.sample.R
 import com.dropbox.android.sample.data.model.Post
 import com.dropbox.android.sample.reddit.PostAdapter
 import com.dropbox.android.sample.utils.Lce
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.fragment_room_store.*
-import kotlinx.android.synthetic.main.activity_store.postRecyclerView
 
 class RedditFragment : Fragment() {
 
     private val viewModel: RedditViewModel by viewModels()
 
     private val adapter = PostAdapter()
+
+    private val pullToRefresh: SwipeRefreshLayout get() = requireView().findViewById(R.id.pullToRefresh)
+
+    private val subredditInput: EditText get() = requireView().findViewById(R.id.subredditInput)
+
+    private val fetchButton: Button get() = requireView().findViewById(R.id.fetchButton)
+
+    private val postRecyclerView: RecyclerView get() = requireView().findViewById(R.id.postRecyclerView)
+
+    private val root: CoordinatorLayout get() = requireView().findViewById(R.id.root)
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_room_store, container, false)

--- a/app/src/main/java/com/dropbox/android/sample/ui/room/RoomFragment.kt
+++ b/app/src/main/java/com/dropbox/android/sample/ui/room/RoomFragment.kt
@@ -4,8 +4,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.EditText
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.dropbox.android.external.store4.ResponseOrigin
 import com.dropbox.android.external.store4.Store
 import com.dropbox.android.external.store4.StoreRequest
@@ -14,8 +19,6 @@ import com.dropbox.android.sample.R
 import com.dropbox.android.sample.SampleApp
 import com.dropbox.android.sample.reddit.PostAdapter
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.activity_store.postRecyclerView
-import kotlinx.android.synthetic.main.fragment_room_store.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.consumeAsFlow
@@ -25,6 +28,16 @@ import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.launch
 
 class RoomFragment : Fragment() {
+
+    private val postRecyclerView : RecyclerView get() = requireView().findViewById(R.id.postRecyclerView)
+
+    private val subredditInput : EditText get() = requireView().findViewById(R.id.subredditInput)
+
+    private val pullToRefresh : SwipeRefreshLayout get() = requireView().findViewById(R.id.pullToRefresh)
+
+    private val root : ConstraintLayout get() = requireView().findViewById(R.id.root)
+
+    private val fetchButton : Button get() = requireView().findViewById(R.id.fetchButton)
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/app/src/main/java/com/dropbox/android/sample/ui/room/RoomFragment.kt
+++ b/app/src/main/java/com/dropbox/android/sample/ui/room/RoomFragment.kt
@@ -29,15 +29,15 @@ import kotlinx.coroutines.launch
 
 class RoomFragment : Fragment() {
 
-    private val postRecyclerView : RecyclerView get() = requireView().findViewById(R.id.postRecyclerView)
+    private val postRecyclerView: RecyclerView get() = requireView().findViewById(R.id.postRecyclerView)
 
-    private val subredditInput : EditText get() = requireView().findViewById(R.id.subredditInput)
+    private val subredditInput: EditText get() = requireView().findViewById(R.id.subredditInput)
 
-    private val pullToRefresh : SwipeRefreshLayout get() = requireView().findViewById(R.id.pullToRefresh)
+    private val pullToRefresh: SwipeRefreshLayout get() = requireView().findViewById(R.id.pullToRefresh)
 
-    private val root : ConstraintLayout get() = requireView().findViewById(R.id.root)
+    private val root: ConstraintLayout get() = requireView().findViewById(R.id.root)
 
-    private val fetchButton : Button get() = requireView().findViewById(R.id.fetchButton)
+    private val fetchButton: Button get() = requireView().findViewById(R.id.fetchButton)
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/app/src/main/java/com/dropbox/android/sample/ui/stream/StreamFragment.kt
+++ b/app/src/main/java/com/dropbox/android/sample/ui/stream/StreamFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.TextView
 import androidx.fragment.app.Fragment
 import com.dropbox.android.external.store4.Fetcher
 import com.dropbox.android.external.store4.MemoryPolicy
@@ -12,7 +14,9 @@ import com.dropbox.android.external.store4.StoreRequest
 import com.dropbox.android.external.store4.fresh
 import com.dropbox.android.external.store4.get
 import com.dropbox.android.sample.R
-import kotlinx.android.synthetic.main.fragment_stream.*
+import kotlin.coroutines.CoroutineContext
+import kotlin.time.ExperimentalTime
+import kotlin.time.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -22,12 +26,23 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flattenMerge
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
-import kotlin.coroutines.CoroutineContext
-import kotlin.time.ExperimentalTime
-import kotlin.time.seconds
 
 @ExperimentalTime
 class StreamFragment : Fragment(), CoroutineScope {
+
+    private val get_1 : Button get() = requireView().findViewById(R.id.get_1)
+
+    private val get_2 : Button get() = requireView().findViewById(R.id.get_2)
+
+    private val fresh_1 : Button get() = requireView().findViewById(R.id.fresh_1)
+
+    private val fresh_2 : Button get() = requireView().findViewById(R.id.fresh_2)
+
+    private val stream_1 : TextView get() = requireView().findViewById(R.id.stream_1)
+
+    private val stream_2 : TextView get() = requireView().findViewById(R.id.stream_2)
+
+    private val stream : TextView get() = requireView().findViewById(R.id.stream)
 
     override val coroutineContext: CoroutineContext = Job() + Dispatchers.Main
 

--- a/app/src/main/java/com/dropbox/android/sample/ui/stream/StreamFragment.kt
+++ b/app/src/main/java/com/dropbox/android/sample/ui/stream/StreamFragment.kt
@@ -30,19 +30,19 @@ import kotlinx.coroutines.launch
 @ExperimentalTime
 class StreamFragment : Fragment(), CoroutineScope {
 
-    private val get_1 : Button get() = requireView().findViewById(R.id.get_1)
+    private val get_1: Button get() = requireView().findViewById(R.id.get_1)
 
-    private val get_2 : Button get() = requireView().findViewById(R.id.get_2)
+    private val get_2: Button get() = requireView().findViewById(R.id.get_2)
 
-    private val fresh_1 : Button get() = requireView().findViewById(R.id.fresh_1)
+    private val fresh_1: Button get() = requireView().findViewById(R.id.fresh_1)
 
-    private val fresh_2 : Button get() = requireView().findViewById(R.id.fresh_2)
+    private val fresh_2: Button get() = requireView().findViewById(R.id.fresh_2)
 
-    private val stream_1 : TextView get() = requireView().findViewById(R.id.stream_1)
+    private val stream_1: TextView get() = requireView().findViewById(R.id.stream_1)
 
-    private val stream_2 : TextView get() = requireView().findViewById(R.id.stream_2)
+    private val stream_2: TextView get() = requireView().findViewById(R.id.stream_2)
 
-    private val stream : TextView get() = requireView().findViewById(R.id.stream)
+    private val stream: TextView get() = requireView().findViewById(R.id.stream)
 
     override val coroutineContext: CoroutineContext = Job() + Dispatchers.Main
 


### PR DESCRIPTION
Kotlin Android Extensions are deprecated, and must be removed before upgrading to AGP 7.

I manually tested the sample app to make sure it still works.