### PR TITLE
Use Java 11 for Publish job

### DIFF
--- a/.github/workflows/.ci_test_and_publish.yml
+++ b/.github/workflows/.ci_test_and_publish.yml
@@ -20,9 +20,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up our JDK environment
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: zulu
+          java-version: 11
 
       - name: Upload Artifacts
         run: ./gradlew publishAllPublicationsToMavenCentralRepository --no-daemon --no-parallel


### PR DESCRIPTION
We updated to Java 11 for the PR checks job https://github.com/dropbox/Store/pull/415 but we didn't do it for the publish job.  This fixes that.