### PR TITLE
Prepare for release 4.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Change Log
 
 The change log for Store version 1.x can be found [here](https://github.com/NYTimes/Store/blob/develop/CHANGELOG.md).
 
+Version 4.0.5 *(2021-03-30)
+----------------------------
+** Update to Kotlin 1.6.10
+
 Version 4.0.4-KT15 *(2021-12-08)
 ----------------------------
 ** Bug fixes and documentation updates

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-#don't use jetifier, all deps are in androidX already android.enableJetifier=true
+# don't use jetifier, all deps are in androidX already android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.caching=true
 org.gradle.configureondemand=true
@@ -6,11 +6,9 @@ org.gradle.configureondemand=true
 # https://github.com/Kotlin/dokka/issues/1405
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=2G
 
-// POM file
+# POM file
 GROUP = com.dropbox.mobile.store
-//e2c5cbfb31bbaa9793f430a25c750195c414ac44 was the last commit compatible with kotlin 1.4
-//if a release with lower compatiblity than kotlin 1.5 is needed, branch off the above commit and cherry pick any newer changes
-VERSION_NAME = 4.0.5-KT15-SNAPSHOT
+VERSION_NAME = 4.0.5
 POM_PACKAGING = pom
 POM_DESCRIPTION = Store4 is built with Kotlin Coroutines
 


### PR DESCRIPTION
Prepare for release 4.0.5

No code changes to the Store library.

Kotlin 1.6.10 dependency bump and updates to the sample application and build plugins.

This release contains [the following changes since `4.0.4-KT15`](https://github.com/dropbox/Store/compare/4.0.4-KT15...4.0.5)