### PR TITLE
Prepare next development version (5.1.0-SNAPSHOT)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=2G
 
 # POM file
 GROUP=org.mobilenativefoundation.store
-VERSION_NAME=5.1.0-alpha08
+VERSION_NAME=5.1.0-SNAPSHOT
 POM_PACKAGING=pom
 POM_DESCRIPTION = Store5 is a Kotlin Multiplatform network-resilient repository layer
 


### PR DESCRIPTION
## Summary

Bumps `VERSION_NAME` from `5.1.0-alpha08` back to `5.1.0-SNAPSHOT` to open the next development cycle, following the [5.1.0-alpha08 release (#729)](https://github.com/MobileNativeFoundation/Store/pull/729).

This follows the repo's standard post-release convention — after each `5.1.0-alphaXX` release, the version is reset to `5.1.0-SNAPSHOT` for ongoing development.

## Test plan

- No functional code changes; only the development version marker in `gradle.properties`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)