### PR TITLE
Fix multicaster race that leaves a new downstream without a producer

### DIFF
--- a/multicast/src/commonMain/kotlin/org/mobilenativefoundation/store/multicast5/ChannelManager.kt
+++ b/multicast/src/commonMain/kotlin/org/mobilenativefoundation/store/multicast5/ChannelManager.kt
@@ -321,6 +321,12 @@ internal class StoreChannelManager<T>(
                 channels.removeAt(index)
                 if (!keepUpstreamAlive && channels.isEmpty()) {
                     producer?.cancelAndJoin()
+                    // Clear the dead producer reference right away instead of waiting for its
+                    // UpstreamFinished message. Otherwise a downstream added before that message
+                    // arrives would not restart the upstream and would never receive a value.
+                    // The stale UpstreamFinished is ignored by the identity check in
+                    // doHandleUpstreamClose.
+                    producer = null
                 }
             }
         }

--- a/multicast/src/commonTest/kotlin/org/mobilenativefoundation/store/multicast5/StoreChannelManagerTests.kt
+++ b/multicast/src/commonTest/kotlin/org/mobilenativefoundation/store/multicast5/StoreChannelManagerTests.kt
@@ -3,6 +3,8 @@ package org.mobilenativefoundation.store.multicast5
 import app.cash.turbine.test
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.filterIsInstance
@@ -11,10 +13,12 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class StoreChannelManagerTests {
     @Test
     fun cancelledDownstreamChannelShouldNotCancelOtherChannels() =
@@ -70,6 +74,48 @@ class StoreChannelManagerTests {
                     awaitComplete()
                 }
             }
+        }
+
+    @Test
+    fun downstreamAddedWhileUpstreamCancellationIsInFlightShouldRestartUpstream() =
+        runTest {
+            var upstreamCollectionCount = 0
+            val upstreamFlow =
+                flow {
+                    upstreamCollectionCount++
+                    if (upstreamCollectionCount == 1) {
+                        awaitCancellation()
+                    } else {
+                        emit(1)
+                    }
+                }
+            val channelManager =
+                StoreChannelManager(
+                    scope = this,
+                    bufferSize = 0,
+                    upstream = upstreamFlow,
+                    piggybackingDownstream = true,
+                    keepUpstreamAlive = false,
+                    onEach = { },
+                )
+            val firstChannel = Channel<ChannelManager.Message.Dispatch.Value<Int>>(Channel.UNLIMITED)
+            val secondChannel = Channel<ChannelManager.Message.Dispatch.Value<Int>>(Channel.UNLIMITED)
+
+            channelManager.addDownstream(firstChannel)
+            advanceUntilIdle()
+
+            // Removing the last downstream makes the actor suspend in doRemove on
+            // producer.cancelAndJoin(). Adding the next downstream right away enqueues its
+            // AddChannel message ahead of the producer's UpstreamFinished message, so the add is
+            // processed while the dead producer reference is still set.
+            channelManager.removeDownstream(firstChannel)
+            channelManager.addDownstream(secondChannel)
+            advanceUntilIdle()
+
+            val dispatchedValue = secondChannel.tryReceive().getOrNull()
+            assertEquals(1, dispatchedValue?.value)
+
+            channelManager.close()
         }
 
     private fun createChannels(count: Int): List<Channel<ChannelManager.Message.Dispatch<Int>>> {


### PR DESCRIPTION
## The bug

`StoreChannelManager` keeps a stale `producer` reference after the producer has been cancelled. When the last downstream is removed, `doRemove` calls `producer?.cancelAndJoin()` but does not clear the field — it waits for the producer's `UpstreamFinished` message to do that. That message is sent asynchronously from `SharedFlowProducer.start()`'s joiner coroutine, so there is a window in which an `AddChannel` message is processed first:

1. `AddChannel(#2)` → `doAdd` → `activateIfNecessary()` sees `producer != null` (dead) → upstream is **not** restarted.
2. `UpstreamFinished` → `doHandleUpstreamClose`: nothing was dispatched (`dispatchedValue == false`), so with `piggybackingDownstream = true` the new downstream is parked as piggybacked, `producer` is set to `null`, and reactivation only happens for `leftovers` (empty).

The new downstream now hangs forever with zero emissions. It only recovers if some later downstream on the same multicaster restarts the producer, which dispatches to piggybacked channels too.

The ordering is easy to hit in practice: `Multicaster.newDownstream()` sends `RemoveChannel` from `onCompletion` and `AddChannel` from `onStart`, so cancelling a collector and immediately re-collecting (a routine "restart the subscription" pattern, e.g. `flatMapLatest`-style UI code over `store.stream()`) races the resubscribe against the in-flight `UpstreamFinished`. Since `FetcherController` builds its multicaster with `piggybackingDownstream = true`, the visible symptom at the Store level is `store.stream()` collectors that never receive anything — we tracked down a production "infinite loading" bug in our app to exactly this race.

## The fix

Clear the `producer` reference in `doRemove` immediately after `cancelAndJoin()`, so a subsequent `AddChannel` starts a fresh producer. This is safe:

- The actor processes messages sequentially, so no concurrent access to the field.
- The cancelled producer's late `UpstreamFinished` is already ignored by the identity check at the top of `doHandleUpstreamClose` (`if (this.producer !== producer) return`).

## Testing

Added a deterministic regression test in `StoreChannelManagerTests`. It runs on a single-threaded test dispatcher and exploits the actor's rendezvous channel: while the actor is suspended in `doRemove`'s `cancelAndJoin()`, the next `addDownstream` parks as a pending sender ahead of `UpstreamFinished`, reproducing the exact production ordering. The upstream suspends on its first collection (fetch in flight, then cancelled) and emits on the second.

- Before the fix: the test fails with `expected:<1> but was:<null>` — the second downstream never receives a value.
- After the fix: `:multicast:jvmTest`, `:store:jvmTest`, and `:multicast:ktlintCheck` all pass.